### PR TITLE
feat: support compilation with TruffleRuby

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install valgrind
-        run: sudo apt-get install valgrind
+        run: sudo apt-get update && sudo apt-get install valgrind
       - name: Set up Ruby 3.4
         uses: ruby/setup-ruby@v1
         with:

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -7,6 +7,14 @@
 #include <assert.h>
 #include <ruby.h>
 
+#ifndef RBASIC_FLAGS
+#define RBASIC_FLAGS(obj) (RBASIC(obj)->flags)
+#endif
+
+#ifndef RBASIC_SET_FLAGS
+#define RBASIC_SET_FLAGS(obj, flags_to_set) (RBASIC(obj)->flags = (flags_to_set))
+#endif
+
 /* global variables within this module */
 VALUE numo_cNArray;
 VALUE rb_mNumo;
@@ -852,8 +860,10 @@ void na_copy_flags(VALUE src, VALUE dst) {
   na2->flag[0] = na1->flag[0];
   // na2->flag[1] = NA_FL1_INIT;
 
-  RBASIC(dst)->flags |= (RBASIC(src)->flags) & (FL_USER1 | FL_USER2 | FL_USER3 | FL_USER4 |
-                                                FL_USER5 | FL_USER6 | FL_USER7);
+  RBASIC_SET_FLAGS(
+    dst, RBASIC_FLAGS(dst) | (RBASIC_FLAGS(src) & (FL_USER1 | FL_USER2 | FL_USER3 | FL_USER4 |
+                                                   FL_USER5 | FL_USER6 | FL_USER7))
+  );
 }
 
 // fix name, ex, allow_stride_for_flatten_view


### PR DESCRIPTION
## Purpose

Hi @yoshoku, this PR fixes a compilation error with TruffleRuby.

```text
compiling ../../../../../ext/numo/narray/narray.c
../../../../../ext/numo/narray/narray.c: In function ‘nary_copy_flags’:
../../../../../ext/numo/narray/narray.c:855:3: error: implicit declaration of function ‘RBASIC’ [-Werror=implicit-function-declaration]
  855 |   RBASIC(dst)->flags |= (RBASIC(src)->flags) & (FL_USER1 | FL_USER2 | FL_USER3 | FL_USER4 |
      |   ^~~~~~
../../../../../ext/numo/narray/narray.c:855:14: error: invalid type argument of ‘->’ (have ‘int’)
  855 |   RBASIC(dst)->flags |= (RBASIC(src)->flags) & (FL_USER1 | FL_USER2 | FL_USER3 | FL_USER4 |
      |              ^~
../../../../../ext/numo/narray/narray.c:855:37: error: invalid type argument of ‘->’ (have ‘int’)
  855 |   RBASIC(dst)->flags |= (RBASIC(src)->flags) & (FL_USER1 | FL_USER2 | FL_USER3 | FL_USER4 |
```

## Summary of Changes

Uses `RBASIC_FLAGS` and `RBASIC_SET_FLAGS` to access flags as recommended in https://github.com/truffleruby/truffleruby/issues/3751.

## Testing

- [x] Tests pass locally (with CRuby)
- [x] Manual testing completed

There are still 16 test failures with TruffleRuby, which can hopefully be addressed in future PRs (see the discussion in https://github.com/truffleruby/truffleruby/issues/3751).

## Related Issues

None
