### PR TITLE
Raise TypeError when `store_binary` receives a non-String

### DIFF
--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1322,6 +1322,7 @@ static VALUE nary_store_binary(int argc, VALUE* argv, VALUE self) {
   narray_t* na;
 
   narg = rb_scan_args(argc, argv, "11", &vstr, &voffset);
+  Check_Type(vstr, T_STRING);
   str_len = RSTRING_LEN(vstr);
   if (narg == 2) {
     offset = NUM2SIZET(voffset);

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -1886,6 +1886,23 @@ class NArrayTest < NArrayTestBase
     end
   end
 
+  def test_store_binary_rejects_non_string
+    a = Numo::DFloat.new(2)
+    [nil, 123, 1.5, :sym, {}, [0x7fffffff, 0x1234].freeze].each do |bad|
+      assert_raises(TypeError) { a.store_binary(bad) }
+    end
+  end
+
+  def test_store_binary_accepts_string
+    a = Numo::DFloat.new(2)
+    assert_equal(16, a.store_binary([1.5, 2.5].pack('d2')))
+    assert_equal(Numo::DFloat[1.5, 2.5], a)
+
+    b = Numo::DFloat.new(1)
+    b.store_binary([9.0, 4.25].pack('d2'), 8)
+    assert_equal(Numo::DFloat[4.25], b)
+  end
+
   def test_diagonal
     a = Numo::DFloat[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     assert_equal(Numo::DFloat[1, 5, 9], a.diagonal)


### PR DESCRIPTION
## Summary

`NArray#store_binary` accepted an object of any type and reinterpreted it as a `struct RString`. Depending on the argument's memory layout the call crashed the process, raised a misleading `ArgumentError`, or — worst of all — succeeded silently while filling the array with unrelated process memory.

`nary_store_binary` passed its argument straight to `RSTRING_LEN` and later `RSTRING_PTR` without a type check. In a release build those macros perform no type check and simply read fields at fixed offsets, so a non-String argument made both the length and the source pointer come from unrelated memory. The sibling constructor `nary_s_from_binary` already does `Check_Type(vstr, T_STRING)` at `narray.c:1250`; `nary_store_binary` was missing the same guard.

## Measured behaviour before the fix

The outcome depends on the argument's memory layout, and it is not uniformly a crash. Measured on this branch's parent commit, x86-64, Ruby 4.0.6:

| Argument | Result |
| --- | --- |
| `nil`, `true`, `false`, `Integer`, `Float`, `Symbol` | `SIGSEGV` |
| `Range`, `Rational`, `Complex`, `Bignum`, `Time`, `Proc`, `Class`, `Module`, `Enumerator`, `Hash`, `Object.new`, `Struct`, small `Array` | `ArgumentError: string is too short to store` |
| **`Regexp`, `MatchData`, `Exception`, `IO`** | **no error — unrelated heap memory is copied into the array** |
| `[0x7fffffff, 0x1234].freeze` | `SIGSEGV` |

The third row is the reason this is worth fixing rather than leaving as a crash-on-misuse:

```ruby
a = Numo::DFloat.new(2)
a.store_binary(/abc/)
a.to_a  # => [6.9108772744551e-310, 0.0]
```

No exception is raised and the return value looks normal, but the array now holds 16 bytes of unrelated process memory, read through the `Regexp`'s internal fields. The denormal values are pointer words reinterpreted as doubles. With a frozen argument the `na_set_pointer` path is taken instead of `memcpy`, so the array keeps pointing at that memory rather than copying it once.

The second row is not a defence. Those arguments survive only because the length field read out of the foreign object happens to be small enough for the existing `byte_size > str_len` check to reject them; it is an accident of struct layout, not validation.
