### PR TITLE
Raise ArgumentError for invalid `reshape` dimension values

### DIFF
--- a/ext/numo/narray/data.c
+++ b/ext/numo/narray/data.c
@@ -325,9 +325,17 @@ static void na_check_reshape(int argc, VALUE* argv, VALUE self, size_t* shape) {
   /* get shape from argument */
   for (i = 0; i < argc; ++i) {
     switch (TYPE(argv[i])) {
-    case T_FIXNUM:
-      total *= shape[i] = NUM2INT(argv[i]);
+    case T_FIXNUM: {
+      ssize_t x = NUM2SSIZET(argv[i]);
+      if (x < 0) {
+        rb_raise(rb_eArgError, "size must be non-negative");
+      }
+      if (x != 0 && total > SIZE_MAX / (size_t)x) {
+        rb_raise(rb_eArgError, "total size is too large");
+      }
+      total *= shape[i] = (size_t)x;
       break;
+    }
     case T_NIL:
     case T_TRUE:
       if (unfixed >= 0) {
@@ -341,6 +349,9 @@ static void na_check_reshape(int argc, VALUE* argv, VALUE self, size_t* shape) {
   }
 
   if (unfixed >= 0) {
+    if (total == 0) {
+      rb_raise(rb_eArgError, "cannot determine unfixed dimension when total size is zero");
+    }
     if (NA_SIZE(na) % total != 0) {
       rb_raise(rb_eArgError, "Total size size must be divisor");
     }

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -1917,6 +1917,32 @@ class NArrayTest < NArrayTestBase
     assert_equal(Numo::DFloat[[1, 2, 3], [4, 5, 6]], a)
   end
 
+  def test_reshape_rejects_negative_size
+    a = Numo::DFloat.new(6).seq
+    assert_raises(ArgumentError) { a.reshape(-2, -3) }
+    assert_raises(ArgumentError) { a.reshape(2, -3) }
+    assert_raises(ArgumentError) { a.reshape(-6) }
+    assert_raises(ArgumentError) { Numo::DFloat.new(1).seq.reshape(-1, -1) }
+    assert_raises(ArgumentError) { Numo::DFloat.new(6).seq.reshape!(-2, -3) }
+  end
+
+  def test_reshape_rejects_zero_total_with_unfixed_dimension
+    assert_raises(ArgumentError) { Numo::Int32[1, 2, 3].reshape(0, nil) }
+    assert_raises(ArgumentError) { Numo::DFloat.new(6).seq.reshape(0, true) }
+  end
+
+  def test_reshape_rejects_overflowing_total
+    assert_raises(ArgumentError) { Numo::DFloat.new(6).seq.reshape(2**30, 2**30, 16, nil) }
+  end
+
+  def test_reshape_unfixed_dimension
+    a = Numo::DFloat.new(6).seq
+    assert_equal([2, 3], a.reshape(2, nil).shape)
+    assert_equal([2, 3], a.reshape(nil, 3).shape)
+    assert_raises(ArgumentError) { a.reshape(4, nil) }
+    assert_raises(ArgumentError) { a.reshape(nil, nil) }
+  end
+
   def test_operation_error_dtype_mismatch
     a = Numo::DFloat[1, 2, 3]
     b = Numo::Int32[4, 5, 6]


### PR DESCRIPTION
## Summary

`NArray#reshape` / `#reshape!` accepted negative dimension values and divided by a total size it never checked for zero. The first produced an array whose declared shape was astronomically larger than its buffer, with no exception raised; the second killed the interpreter with `SIGFPE`.

`na_check_reshape` read each dimension with `NUM2INT` and stored it directly into the `size_t` shape array, using the wrapping product as the only consistency check.

## Measured behaviour before the fix

Measured on this branch's parent commit, x86-64, Ruby 4.0.6.

**Negative sizes were accepted.** `NUM2INT` returns the negative value, which becomes a near-`SIZE_MAX` entry in the shape array, and the wrapping product multiplies back to the correct total, so the size check passes:

```ruby
Numo::DFloat.new(6).seq.reshape(-2, -3).shape
# => [18446744073709551614, 18446744073709551613]

Numo::DFloat.new(1).seq.reshape(-1, -1).shape
# => [18446744073709551615, 18446744073709551615]
```

No exception is raised. The array's declared shape is now far larger than its 48-byte buffer, so any later shape-driven loop (`fill`, `seq`, `inspect`, `to_a`, arithmetic) walks past the allocation. `reshape(-1, -1)` on a one-element array is an equally effective and completely innocent-looking trigger — a habit carried over from numpy, where negative dimensions are meaningful, reaches it directly.

`na_array_to_internal_shape` already rejects negative sizes at `narray.c:270`; this path did not.

**The product was used as a divisor without a zero check.** When a dimension is left unfixed with `nil` / `true`, `NA_SIZE(na) % total` runs with `total` possibly zero:

```ruby
Numo::Int32[1, 2, 3].reshape(0, nil)                   # SIGFPE
Numo::DFloat.new(6).seq.reshape(2**30, 2**30, 16, nil) # SIGFPE (product wraps to 0)
```

`SIGFPE` cannot be rescued from Ruby, so a single call terminates the interpreter.
