### PR TITLE
Fix a buffer over-read, a SIGFPE and an abort in `index.c`

### DIFF
--- a/ext/numo/narray/index.c
+++ b/ext/numo/narray/index.c
@@ -481,13 +481,17 @@ static void na_index_aref_nadata(
   na_get_strides_nadata(na1, strides_na1, elmsz);
 
   for (i = j = 0; i < ndim; i++) {
-    stride1 = strides_na1[q[i].orig_dim];
+    const int qi_orig_dim = q[i].orig_dim;
+    stride1 = 0;
+    if (qi_orig_dim < na1->base.ndim) {
+      stride1 = strides_na1[qi_orig_dim];
 
-    // numeric index -- trim dimension
-    if (!keep_dim && q[i].n == 1 && q[i].step == 0) {
-      beg = q[i].beg;
-      na2->offset += stride1 * beg;
-      continue;
+      // numeric index -- trim dimension
+      if (!keep_dim && q[i].n == 1 && q[i].step == 0) {
+        beg = q[i].beg;
+        na2->offset += stride1 * beg;
+        continue;
+      }
     }
 
     na2->base.shape[j] = size = q[i].n;
@@ -497,8 +501,11 @@ static void na_index_aref_nadata(
       na2->base.reduce = rb_funcall(m, '|', 1, na2->base.reduce);
     }
 
-    // array index
-    if (q[i].idx != NULL) {
+    if (qi_orig_dim >= na1->base.ndim) {
+      // new dimension
+      SDX_SET_STRIDE(na2->stridx[j], elmsz);
+    } else if (q[i].idx != NULL) {
+      // array index
       index = q[i].idx;
       SDX_SET_INDEX(na2->stridx[j], index);
       q[i].idx = NULL;

--- a/ext/numo/narray/index.c
+++ b/ext/numo/narray/index.c
@@ -183,7 +183,13 @@ na_parse_range(VALUE range, ssize_t step, int orig_dim, ssize_t size, na_index_a
 
   rb_arithmetic_sequence_components_t x;
   rb_arithmetic_sequence_extract(range, &x);
+  if (!RB_INTEGER_TYPE_P(x.step)) {
+    rb_raise(rb_eArgError, "step must be an Integer");
+  }
   step = NUM2SSIZET(x.step);
+  if (step == 0) {
+    rb_raise(rb_eArgError, "step must not be zero");
+  }
 
   beg = beg_orig = NUM2SSIZET(x.begin);
   if (beg < 0) {

--- a/ext/numo/narray/index.c
+++ b/ext/numo/narray/index.c
@@ -126,7 +126,7 @@ static void na_parse_narray_index(VALUE a, int orig_dim, ssize_t size, na_index_
     GetNArray(idx, nidx);
     n = NA_SIZE(nidx);
     q->idx = ALLOC_N(size_t, n);
-    if (na->type != NARRAY_DATA_T) {
+    if (nidx->type != NARRAY_DATA_T) {
       rb_bug("NArray#where returned wrong type of NArray");
     }
     if (rb_obj_class(idx) == numo_cInt32) {

--- a/test/test_bit.rb
+++ b/test/test_bit.rb
@@ -112,6 +112,14 @@ class NArrayBitTest < NArrayTestBase
     assert_equal([1, nil, 3], x.to_a)
   end
 
+  def test_index_by_bit_view
+    a = Numo::DFloat.new(3, 3).seq
+    bit = Numo::Bit[1, 0, 1]
+    assert_equal([0.0, 6.0], a[bit, 0].to_a)
+    assert_equal([0.0, 6.0], a[bit[0..2], 0].to_a)
+    assert_equal([0.0, 6.0], a[bit[true], 0].to_a)
+  end
+
   def test_flipud
     m = Numo::Bit.zeros(7, 7)
     m = m.flipud

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -747,6 +747,24 @@ class NArrayTest < NArrayTestBase
     assert_raises(ArgumentError) { a.at((0..9).step(0.5)) }
   end
 
+  def test_new_axis_on_data_array
+    a = Numo::DFloat.new(4).seq
+    assert_equal([4, 1], a[true, :new].shape)
+    assert_equal([[0.0], [1.0], [2.0], [3.0]], a[true, :new].to_a)
+    assert_equal([1, 4], a[:new, true].shape)
+    assert_equal([[0.0, 1.0, 2.0, 3.0]], a[:new, true].to_a)
+
+    b = Numo::DFloat.new(2, 3).seq
+    assert_equal([2, 3, 1], b[true, true, :new].shape)
+    assert_equal(b.to_a.map(&:zip), b[true, true, :new].to_a)
+  end
+
+  def test_new_axis_on_view
+    a = Numo::DFloat.new(6).seq[0..3]
+    assert_equal([4, 1], a[true, :new].shape)
+    assert_equal([[0.0], [1.0], [2.0], [3.0]], a[true, :new].to_a)
+  end
+
   def test_nearly_eq # rubocop:disable Metrics/AbcSize
     a = Numo::SFloat[1.0, 1.0, 1.0, 1.0]
     b = Numo::SFloat[1.0 + 1e-7, 1.0 - 1e-7, 1.0 + 1e-6, 1.0 - 1e-6]

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -739,6 +739,14 @@ class NArrayTest < NArrayTestBase
     end
   end
 
+  def test_indexing_rejects_non_integer_step
+    a = Numo::DFloat.new(10).seq
+    assert_raises(ArgumentError) { a[(0..9).step(0.5)] }
+    assert_raises(ArgumentError) { a[(0..9).step(1.5)] }
+    assert_raises(ArgumentError) { a[(0..9) % 0.5] }
+    assert_raises(ArgumentError) { a.at((0..9).step(0.5)) }
+  end
+
   def test_nearly_eq # rubocop:disable Metrics/AbcSize
     a = Numo::SFloat[1.0, 1.0, 1.0, 1.0]
     b = Numo::SFloat[1.0 + 1e-7, 1.0 - 1e-7, 1.0 + 1e-6, 1.0 - 1e-6]


### PR DESCRIPTION
## Summary

Three independent defects in `index.c`, one commit each. All are reachable from ordinary indexing expressions.

1. `na_index_aref_nadata` reads past an `ALLOCA_N` buffer when a newaxis follows the real dimensions.
2. `na_parse_range` divides by a step it never checks, so a fractional step kills the interpreter with `SIGFPE`.
3. `na_parse_narray_index` type-checks the wrong object, so a `Bit` view used as an index aborts the interpreter through `rb_bug`.

## 1. Out-of-bounds read on the data-array indexing path

`na_index_aref_naview` was given a bounds check on `q[i].orig_dim` in cd2f136a3d, but the symmetric data-array path never got one. `na_index_aref_nadata` indexes a buffer of exactly `base.ndim` entries:

```c
strides_na1 = ALLOCA_N(ssize_t, na1->base.ndim);
na_get_strides_nadata(na1, strides_na1, elmsz);

for (i = j = 0; i < ndim; i++) {
    stride1 = strides_na1[q[i].orig_dim];   // no bounds check
```

A trailing newaxis makes `orig_dim` equal to `base.ndim`. `na_index_parse_args` advances `j` but not `k` for `:new`, so the new axis inherits the `k` of the dimension past the end. `na_aref_md_protected` routes a plain, non-view NArray to this path, so the guard added for views never applies to it.

The most ordinary newaxis expression triggers it:

```ruby
Numo::DFloat.new(4).seq[true, :new]
```

AddressSanitizer, on the parent commit:

```
ERROR: AddressSanitizer: dynamic-stack-buffer-overflow
READ of size 8
    #0 na_index_aref_nadata   ext/numo/narray/index.c:478
    #1 na_aref_md_protected   ext/numo/narray/index.c:677
    #4 nary_aref_main         ext/numo/narray/index.c:760
    #5 dfloat_aref            src/t_dfloat.c:166
```

**The existing test suite already triggers this.** Running `test/test_bit.rb` on the parent commit under ASan reports the same overflow, reached through `bit_aref` at `src/t_bit.c:49`.

Which expressions reach it, measured on the parent commit:

| Expression | ASan |
| --- | --- |
| `DFloat.new(4).seq[true, :new]` | **overflow** |
| `DFloat.new(2,3).seq[true, true, :new]` | **overflow** |
| `Int32.new(4).seq[true, :new]` | **overflow** |
| `DFloat.new(4).seq[:new, true]` | clean |
| `DFloat.new(6).seq[0..3][true, :new]` (view) | clean |
| `DFloat.new(2,3).seq[0..1,0..1][true, true, :new]` (view) | clean |
| three controls without newaxis | clean |

Only a *trailing* newaxis is affected: with a leading `:new`, `k` has not advanced yet, so the following real dimension keeps `orig_dim` in range. The view rows being clean is cd2f136a3d working, and is what makes the asymmetry visible in the same measurement.

**It does not crash or corrupt the result.** The value read becomes the stride of a size-1 dimension whose only valid index is zero, so nothing observable depends on it — shapes and values are correct before and after this change. No escalation to an information leak or an out-of-bounds write was found.

**Valgrind does not detect it.** On the parent commit, `narray.so` produces zero errors under memcheck; the errors it does report come from Ruby's conservative GC scanning. Memcheck reports an uninitialised value only once it reaches a branch, a syscall, or an address computation, and here it reaches none of those. The `memcheck` CI workflow uses `ruby_memcheck`, which is valgrind-based, so this class of defect does not show up there.

Fixed by guarding the read the way the view path does, and setting the stride of a new dimension to `elmsz` instead of to whatever followed the buffer.

## 2. Division by an unchecked step in range indexing

`na_parse_range` takes the step of a `Range` or `Enumerator::ArithmeticSequence` index through `NUM2SSIZET`, which truncates a `Float`, and then uses it as a divisor:

```c
n = (int)((end - beg) / step + 1);
```

A fractional step below 1 truncates to zero, so an ordinary index expression divides by zero:

```ruby
arr[(0..9).step(0.5)]   # SIGFPE, not rescuable from Ruby
arr[(0..9) % 0.5]       # same
```

A fractional step above 1 was silently truncated instead — `arr[(0..9).step(1.5)]` walked with step 1, a step the caller never asked for.

Fixed by rejecting a step that is not an `Integer`, which covers both, plus an explicit zero check so the invariant the division depends on is stated where it is needed.

This narrows what is accepted: a `Float` step is now an `ArgumentError` even when it is integral, e.g. `step(2.0)`. Every step in the existing suite is an `Integer`, so nothing there changes.

## 3. Reachable `rb_bug` abort when indexing with a Bit view

`na_parse_narray_index` guarded the Bit-index path with `na->type` — the caller's Bit array — and then dereferenced `nidx`, the Int32/Int64 array that `where()` returned:

```c
idx = rb_funcall(a, id_where, 0);
GetNArray(idx, nidx);
q->idx = ALLOC_N(size_t, n);
if (na->type != NARRAY_DATA_T) {          // wrong object
    rb_bug("NArray#where returned wrong type of NArray");
}
... NA_DATA_PTR(nidx) ...                  // the object actually read
```

Slicing a Bit array makes it a `NARRAY_VIEW_T`, so passing a Bit view as one of several indices trips the guard even though `where()` returned a perfectly valid data array. `rb_bug` prints an internal crash report and calls `abort()`, which Ruby cannot rescue:

```ruby
Numo::DFloat.new(3,3).seq[Numo::Bit[1,0,1][0..2], 0]
```

Fixed by testing `nidx->type`, the object `NA_DATA_PTR` actually reads. That check now holds by construction, so the `rb_bug` is no longer reachable from Ruby.

## Tests

Four tests added.

- `test_new_axis_on_data_array` (`test/test_narray.rb`) — shapes and values for a trailing newaxis on 1-D and 2-D data arrays, and for a leading newaxis.
- `test_new_axis_on_view` (`test/test_narray.rb`) — the same for a view, so the two paths stay symmetric.
- `test_indexing_rejects_non_integer_step` (`test/test_narray.rb`) — `step(0.5)`, `step(1.5)`, `% 0.5` and `at(...)` all raise `ArgumentError`.
- `test_index_by_bit_view` (`test/test_bit.rb`) — indexing with a Bit array, a sliced Bit view and `bit[true]` all return the same result.

The newaxis tests assert shapes and values only. They do not fail on the parent commit, because the out-of-bounds read has no observable effect; ASan is what distinguishes the two. They are there to keep the data-array and view paths in step.

## Verification

- Full test suite passes: 195 runs, 20156 assertions, 0 failures, 0 errors, 0 skips.
- Under AddressSanitizer, `test_narray.rb`, `test_bit.rb`, `test_extra.rb` and `test_math.rb` report zero memory-safety errors. On the parent commit, `test_bit.rb` reports the `dynamic-stack-buffer-overflow` above.
- `clang-format -style=file -Werror --dry-run` clean on `index.c`; `rubocop` clean on both test files.
- Every expression in the tables above was run against the parent commit and against this branch.

Not run: the `BUNDLE_WITH=memcheck` task. Bundler could not resolve the `Gemfile` in this environment (`rdoc ~> 6.15` unavailable), so the extension was built directly with `extconf.rb` and `make`, and the tests were run with `ruby -I lib -I test`.

## Notes

This touches only `ext/numo/narray/index.c`, `test/test_narray.rb` and `test/test_bit.rb`, so it does not overlap #14, #15 or #16 and can be reviewed in any order relative to them. The three fixes are independent and are kept as one commit each.
