### PR TITLE
Fix a stack buffer overflow in `Numo::RObject#format`

### DIFF
--- a/ext/numo/narray/numo/types/robj_macro.h
+++ b/ext/numo/narray/numo/types/robj_macro.h
@@ -68,13 +68,6 @@
 
 #define m_mulsum_init INT2FIX(0)
 
-#define m_sprintf(s, x) robj_sprintf(s, x)
-
-static inline int robj_sprintf(char* s, VALUE x) {
-  VALUE v = rb_funcall(x, rb_intern("to_s"), 0);
-  return sprintf(s, "%s", StringValuePtr(v));
-}
-
 #define m_sqrt(x)                                                                              \
   rb_funcall(rb_const_get(rb_mKernel, rb_intern("Math")), rb_intern("sqrt"), 1, x);
 

--- a/ext/numo/narray/src/mh/format.h
+++ b/ext/numo/narray/src/mh/format.h
@@ -1,7 +1,7 @@
 #ifndef NUMO_NARRAY_MH_FORMAT_H
 #define NUMO_NARRAY_MH_FORMAT_H 1
 
-#define DEF_NARRAY_FORMAT_METHOD_FUNC(tDType)                                                  \
+#define DEF_NARRAY_FORMAT_ELEMENT_FUNC(tDType)                                                 \
   static VALUE format_##tDType(VALUE fmt, tDType* x) {                                         \
     if (NIL_P(fmt)) {                                                                          \
       char s[48];                                                                              \
@@ -9,8 +9,22 @@
       return rb_str_new(s, n);                                                                 \
     }                                                                                          \
     return rb_funcall(fmt, '%', 1, m_data_to_num(*x));                                         \
-  }                                                                                            \
-                                                                                               \
+  }
+
+/* robject formats its element without the fixed buffer above: the element is an
+   arbitrary Ruby object, so the length of its to_s is not bounded by anything
+   this side controls. */
+#define DEF_NARRAY_ROBJ_FORMAT_ELEMENT_FUNC()                                                  \
+  static VALUE format_robject(VALUE fmt, robject* x) {                                         \
+    if (NIL_P(fmt)) {                                                                          \
+      VALUE v = rb_funcall(*x, id_to_s, 0);                                                    \
+      StringValue(v);                                                                          \
+      return rb_str_new(RSTRING_PTR(v), RSTRING_LEN(v));                                       \
+    }                                                                                          \
+    return rb_funcall(fmt, '%', 1, m_data_to_num(*x));                                         \
+  }
+
+#define DEF_NARRAY_FORMAT_LOOP_METHOD_FUNC(tDType)                                             \
   static void iter_##tDType##_format(na_loop_t* const lp) {                                    \
     size_t n;                                                                                  \
     char* p1;                                                                                  \
@@ -51,5 +65,13 @@
     rb_scan_args(argc, argv, "01", &fmt);                                                      \
     return na_ndloop(&ndf, 2, self, fmt);                                                      \
   }
+
+#define DEF_NARRAY_FORMAT_METHOD_FUNC(tDType)                                                  \
+  DEF_NARRAY_FORMAT_ELEMENT_FUNC(tDType)                                                       \
+  DEF_NARRAY_FORMAT_LOOP_METHOD_FUNC(tDType)
+
+#define DEF_NARRAY_ROBJ_FORMAT_METHOD_FUNC()                                                   \
+  DEF_NARRAY_ROBJ_FORMAT_ELEMENT_FUNC()                                                        \
+  DEF_NARRAY_FORMAT_LOOP_METHOD_FUNC(robject)
 
 #endif /* NUMO_NARRAY_MH_FORMAT_H */

--- a/ext/numo/narray/src/t_robject.c
+++ b/ext/numo/narray/src/t_robject.c
@@ -45,6 +45,7 @@ static ID id_reciprocal;
 static ID id_round;
 static ID id_square;
 static ID id_to_a;
+static ID id_to_s;
 static ID id_truncate;
 
 #include <numo/types/robject.h>
@@ -141,7 +142,7 @@ DEF_NARRAY_ASET_METHOD_FUNC(robject)
 DEF_NARRAY_COERCE_CAST_METHOD_FUNC(robject)
 DEF_NARRAY_TO_A_METHOD_FUNC(robject)
 DEF_NARRAY_FILL_METHOD_FUNC(robject)
-DEF_NARRAY_FORMAT_METHOD_FUNC(robject)
+DEF_NARRAY_ROBJ_FORMAT_METHOD_FUNC()
 DEF_NARRAY_FORMAT_TO_A_METHOD_FUNC(robject)
 DEF_NARRAY_ROBJ_INSPECT_METHOD_FUNC()
 DEF_NARRAY_EACH_METHOD_FUNC(robject)
@@ -365,6 +366,7 @@ void Init_numo_robject(void) {
   id_round = rb_intern("round");
   id_square = rb_intern("square");
   id_to_a = rb_intern("to_a");
+  id_to_s = rb_intern("to_s");
   id_truncate = rb_intern("truncate");
 
   /**

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -1681,6 +1681,20 @@ class NArrayTest < NArrayTestBase
     assert_equal(6, Numo::RObject.cast([1.0, 2.0, 3.0]).sum)
   end
 
+  def test_robject_format_long_element
+    ['A' * 47, 'A' * 48, 'A' * 4096].each do |src|
+      a = Numo::RObject[src]
+
+      formatted = a.format
+      assert_kind_of(Numo::RObject, formatted)
+      assert_equal(src, formatted[0])
+
+      formatted = a.format_to_a
+      assert_kind_of(Array, formatted)
+      assert_equal([src], formatted)
+    end
+  end
+
   def test_dfloat_cast_robject
     assert_equal(Numo::DFloat[1, Float::NAN, 3].format_to_a,
                  Numo::DFloat.cast(Numo::RObject[1, nil, 3]).format_to_a)


### PR DESCRIPTION
## Summary

`Numo::RObject#format` writes the text of each element into a 48-byte stack buffer with an unbounded `sprintf`. `format_robject` declares `char s[48]` and passes it to `m_sprintf`, which for `Numo::RObject` expands to `sprintf(s, "%s", StringValuePtr(v))` where `v` is the element's `to_s`. The text of an arbitrary Ruby object has no length bound, so an element longer than 47 bytes writes past the buffer, across the saved registers and the return address, with the bytes chosen by whoever supplied the element. `#format_to_a` reaches the same code.

This gives `robject` its own element formatter, following the `DEF_NARRAY_ROBJ_*` pattern already used for `store`, `inspect` and `map`, and builds the `String` from the `to_s` result directly. The loop and the method body stay shared with the other types, which keep the small buffer: their `m_sprintf` writes a number through a format string of bounded width. `robj_sprintf` is removed together with its only caller.

One behaviour changes. The buffer ended the text at the first NUL byte, so an element containing one now formats in full: `"ab\0cd"` was `"ab"`. Nothing else does -- the result is still a fresh ASCII-8BIT `String`, an explicit format argument still goes through `String#%`, and a `to_s` that returns a non-String still raises `TypeError`.

## Measured behaviour before the fix

On v0.11.1:

```ruby
Numo::RObject.cast(['A' * 4096]).format
# *** stack smashing detected ***: terminated
# [BUG] Aborted at 0x000003e800053af8
#
# -- Control frame information ---
# c:0003 p:---- s:0011 e:000010 l:y b:0001 CFUNC  :format
```

The overflow starts one byte past the buffer, well before the write reaches the canary:

| element length | `#format` | `#format_to_a` |
| --- | --- | --- |
| 47 bytes | returns the string | returns the string |
| 48 bytes | returns the string, 49 bytes written into `char s[48]` | same |
| 64 bytes | `*** stack smashing detected ***`, abort | returns the string |
| 4096 bytes | `*** stack smashing detected ***`, abort | `*** stack smashing detected ***`, abort |

The rows that return normally are the dangerous ones: the write is out of bounds but lands short of the canary, so nothing reports it. AddressSanitizer shows the boundary exactly:

```
$ make optflags="-O0 -g -fsanitize=address -fno-omit-frame-pointer" DLDFLAGS="-fsanitize=address -shared"
$ ruby -e "require 'numo/narray'; Numo::RObject.cast(['A' * 48]).format"

==343432==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7b71c7bf0460
WRITE of size 49 at 0x7b71c7bf0460 thread T0
    #0 vsprintf
    #1 sprintf
    #2 robj_sprintf numo/types/robj_macro.h:75
    #3 format_robject src/t_robject.c:144
    #4 iter_robject_format src/t_robject.c:144
Address 0x7b71c7bf0460 is located in stack of thread T0 at offset 96 in frame
```

After the fix the same input formats to a 4096-byte string, and AddressSanitizer is silent.
