### PR TITLE
Fix a use-after-free, a heap buffer overflow and an uninitialised read in `store_array`

### DIFF
--- a/ext/numo/narray/src/mh/store.h
+++ b/ext/numo/narray/src/mh/store.h
@@ -1,6 +1,20 @@
 #ifndef NUMO_NARRAY_MH_STORE_H
 #define NUMO_NARRAY_MH_STORE_H 1
 
+/* The store loops below run Ruby code for every element, which can reallocate or
+   shrink the array being read: its buffer and length do not survive one. */
+static inline bool na_store_rary_fetch(VALUE ary, size_t i, VALUE* x) {
+  if (!RB_TYPE_P(ary, T_ARRAY)) {
+    *x = ary;
+    return true;
+  }
+  if (i >= (size_t)RARRAY_LEN(ary)) {
+    return false;
+  }
+  *x = RARRAY_AREF(ary, (long)i);
+  return true;
+}
+
 #define DEF_STORE_NUMERIC_FUNC(tDType, tNAryClass)                                             \
   static VALUE tDType##_store(VALUE, VALUE);                                                   \
                                                                                                \
@@ -134,7 +148,6 @@
     size_t i1;                                                                                 \
     size_t n1;                                                                                 \
     VALUE v1;                                                                                  \
-    VALUE* ptr;                                                                                \
     VALUE x;                                                                                   \
     double y;                                                                                  \
     tDType z;                                                                                  \
@@ -162,11 +175,9 @@
       }                                                                                        \
       goto loop_end;                                                                           \
     }                                                                                          \
-    ptr = &v1;                                                                                 \
     switch (TYPE(v1)) {                                                                        \
     case T_ARRAY:                                                                              \
       n1 = RARRAY_LEN(v1);                                                                     \
-      ptr = RARRAY_PTR(v1);                                                                    \
       break;                                                                                   \
     case T_NIL:                                                                                \
       n1 = 0;                                                                                  \
@@ -176,7 +187,7 @@
     }                                                                                          \
     if (idx1) {                                                                                \
       for (i = i1 = 0; i1 < n1 && i < n; i++, i1++) {                                          \
-        x = ptr[i1];                                                                           \
+        if (!na_store_rary_fetch(v1, i1, &x)) break;                                           \
         if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {           \
           nary_step_sequence(x, &len, &beg, &step);                                            \
           for (c = 0; c < len && i < n; c++, i++) {                                            \
@@ -191,7 +202,7 @@
       }                                                                                        \
     } else {                                                                                   \
       for (i = i1 = 0; i1 < n1 && i < n; i++, i1++) {                                          \
-        x = ptr[i1];                                                                           \
+        if (!na_store_rary_fetch(v1, i1, &x)) break;                                           \
         if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {           \
           nary_step_sequence(x, &len, &beg, &step);                                            \
           for (c = 0; c < len && i < n; c++, i++) {                                            \

--- a/ext/numo/narray/src/mh/store.h
+++ b/ext/numo/narray/src/mh/store.h
@@ -186,7 +186,7 @@ static inline bool na_store_rary_fetch(VALUE ary, size_t i, VALUE* x) {
       n1 = 1;                                                                                  \
     }                                                                                          \
     if (idx1) {                                                                                \
-      for (i = i1 = 0; i1 < n1 && i < n; i++, i1++) {                                          \
+      for (i = i1 = 0; i1 < n1 && i < n; i1++) {                                               \
         if (!na_store_rary_fetch(v1, i1, &x)) break;                                           \
         if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {           \
           nary_step_sequence(x, &len, &beg, &step);                                            \
@@ -198,10 +198,11 @@ static inline bool na_store_rary_fetch(VALUE ary, size_t i, VALUE* x) {
         } else if (TYPE(x) != T_ARRAY) {                                                       \
           z = m_num_to_data(x);                                                                \
           SET_DATA_INDEX(p1, idx1, tDType, z);                                                 \
+          i++;                                                                                 \
         }                                                                                      \
       }                                                                                        \
     } else {                                                                                   \
-      for (i = i1 = 0; i1 < n1 && i < n; i++, i1++) {                                          \
+      for (i = i1 = 0; i1 < n1 && i < n; i1++) {                                               \
         if (!na_store_rary_fetch(v1, i1, &x)) break;                                           \
         if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {           \
           nary_step_sequence(x, &len, &beg, &step);                                            \
@@ -213,6 +214,7 @@ static inline bool na_store_rary_fetch(VALUE ary, size_t i, VALUE* x) {
         } else if (TYPE(x) != T_ARRAY) {                                                       \
           z = m_num_to_data(x);                                                                \
           SET_DATA_STRIDE(p1, s1, tDType, z);                                                  \
+          i++;                                                                                 \
         }                                                                                      \
       }                                                                                        \
     }                                                                                          \

--- a/ext/numo/narray/src/t_bit.c
+++ b/ext/numo/narray/src/t_bit.c
@@ -1293,7 +1293,7 @@ static void iter_bit_store_array(na_loop_t* const lp) {
   }
 
   if (idx1) {
-    for (i = i1 = 0; i1 < n1 && i < n; i++, i1++) {
+    for (i = i1 = 0; i1 < n1 && i < n; i1++) {
       if (!na_store_rary_fetch(v1, i1, &x)) break;
       if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
         nary_step_sequence(x, &len, &beg, &step);
@@ -1308,10 +1308,11 @@ static void iter_bit_store_array(na_loop_t* const lp) {
         z = m_num_to_data(x);
         STORE_BIT(a1, p1 + *idx1, z);
         idx1++;
+        i++;
       }
     }
   } else {
-    for (i = i1 = 0; i1 < n1 && i < n; i++, i1++) {
+    for (i = i1 = 0; i1 < n1 && i < n; i1++) {
       if (!na_store_rary_fetch(v1, i1, &x)) break;
       if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
         nary_step_sequence(x, &len, &beg, &step);
@@ -1325,6 +1326,7 @@ static void iter_bit_store_array(na_loop_t* const lp) {
         z = m_num_to_data(x);
         STORE_BIT(a1, p1, z);
         p1 += s1;
+        i++;
       }
     }
   }

--- a/ext/numo/narray/src/t_bit.c
+++ b/ext/numo/narray/src/t_bit.c
@@ -1303,8 +1303,7 @@ static void iter_bit_store_array(na_loop_t* const lp) {
           STORE_BIT(a1, p1 + *idx1, z);
           idx1++;
         }
-      }
-      if (TYPE(x) != T_ARRAY) {
+      } else if (TYPE(x) != T_ARRAY) {
         if (x == Qnil) x = INT2FIX(0);
         z = m_num_to_data(x);
         STORE_BIT(a1, p1 + *idx1, z);
@@ -1322,8 +1321,7 @@ static void iter_bit_store_array(na_loop_t* const lp) {
           STORE_BIT(a1, p1, z);
           p1 += s1;
         }
-      }
-      if (TYPE(x) != T_ARRAY) {
+      } else if (TYPE(x) != T_ARRAY) {
         z = m_num_to_data(x);
         STORE_BIT(a1, p1, z);
         p1 += s1;

--- a/ext/numo/narray/src/t_bit.c
+++ b/ext/numo/narray/src/t_bit.c
@@ -9,6 +9,7 @@
 #include <ruby.h>
 
 #include "SFMT.h"
+#include "mh/store.h"
 #include "numo/narray.h"
 #include "numo/template.h"
 
@@ -1252,7 +1253,7 @@ static VALUE bit_store_robject(VALUE self, VALUE obj) {
 static void iter_bit_store_array(na_loop_t* const lp) {
   size_t i, n;
   size_t i1, n1;
-  VALUE v1, *ptr;
+  VALUE v1;
   BIT_DIGIT* a1;
   size_t p1;
   size_t s1, *idx1;
@@ -1280,12 +1281,9 @@ static void iter_bit_store_array(na_loop_t* const lp) {
     goto loop_end;
   }
 
-  ptr = &v1;
-
   switch (TYPE(v1)) {
   case T_ARRAY:
     n1 = RARRAY_LEN(v1);
-    ptr = RARRAY_PTR(v1);
     break;
   case T_NIL:
     n1 = 0;
@@ -1296,7 +1294,7 @@ static void iter_bit_store_array(na_loop_t* const lp) {
 
   if (idx1) {
     for (i = i1 = 0; i1 < n1 && i < n; i++, i1++) {
-      x = ptr[i1];
+      if (!na_store_rary_fetch(v1, i1, &x)) break;
       if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
         nary_step_sequence(x, &len, &beg, &step);
         for (c = 0; c < len && i < n; c++, i++) {
@@ -1315,7 +1313,7 @@ static void iter_bit_store_array(na_loop_t* const lp) {
     }
   } else {
     for (i = i1 = 0; i1 < n1 && i < n; i++, i1++) {
-      x = ptr[i1];
+      if (!na_store_rary_fetch(v1, i1, &x)) break;
       if (rb_obj_is_kind_of(x, rb_cRange) || rb_obj_is_kind_of(x, rb_cArithSeq)) {
         nary_step_sequence(x, &len, &beg, &step);
         for (c = 0; c < len && i < n; c++, i++) {

--- a/test/test_bit.rb
+++ b/test/test_bit.rb
@@ -106,6 +106,21 @@ class NArrayBitTest < NArrayTestBase
     assert_empty(y[true, true, 1].where)
   end
 
+  def test_store_array_emptied_by_conversion
+    emptier = Class.new do
+      def initialize(ary) = @ary = ary
+
+      def ==(_other)
+        @ary.replace([])
+        false
+      end
+    end
+    ary = Array.new(8, 1)
+    ary[0] = emptier.new(ary)
+
+    assert_equal([1, 0, 0, 0, 0, 0, 0, 0], Numo::Bit.ones(8).store(ary).to_a)
+  end
+
   def test_assign_nil
     x = Numo::RObject.cast([1, 2, 3])
     x[Numo::Bit.cast([0, 1, 0])] = nil

--- a/test/test_bit.rb
+++ b/test/test_bit.rb
@@ -126,6 +126,10 @@ class NArrayBitTest < NArrayTestBase
     assert_equal([0] + ([1] * 63), Numo::Bit.cast([(0...64)]).to_a)
   end
 
+  def test_store_array_fills_every_slot_after_a_range
+    assert_equal([0, 1, 0, 0], Numo::Bit.ones(4).store([(0...2), 0, 0]).to_a)
+  end
+
   def test_assign_nil
     x = Numo::RObject.cast([1, 2, 3])
     x[Numo::Bit.cast([0, 1, 0])] = nil

--- a/test/test_bit.rb
+++ b/test/test_bit.rb
@@ -121,6 +121,11 @@ class NArrayBitTest < NArrayTestBase
     assert_equal([1, 0, 0, 0, 0, 0, 0, 0], Numo::Bit.ones(8).store(ary).to_a)
   end
 
+  def test_store_array_range_element_is_stored_once
+    assert_equal([0, 1, 0, 0], Numo::Bit.zeros(4).store([(0...2)]).to_a)
+    assert_equal([0] + ([1] * 63), Numo::Bit.cast([(0...64)]).to_a)
+  end
+
   def test_assign_nil
     x = Numo::RObject.cast([1, 2, 3])
     x[Numo::Bit.cast([0, 1, 0])] = nil

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -1695,6 +1695,58 @@ class NArrayTest < NArrayTestBase
     end
   end
 
+  def test_store_array_grown_by_conversion
+    grower = Class.new do
+      def initialize(ary) = @ary = ary
+
+      def to_int
+        200.times { @ary << 0 }
+        1
+      end
+    end
+    ary = Array.new(8) { |i| i + 100 }
+    ary[0] = grower.new(ary)
+
+    assert_equal([1, 101, 102, 103, 104, 105, 106, 107], Numo::Int32.cast(ary).to_a)
+  end
+
+  def test_store_array_emptied_by_conversion
+    emptier = Class.new do
+      def initialize(ary) = @ary = ary
+
+      def to_f
+        @ary.replace([])
+        9.0
+      end
+    end
+    ary = Array.new(8) { |i| i + 100.0 }
+    ary[0] = emptier.new(ary)
+
+    assert_equal([9.0, 0, 0, 0, 0, 0, 0, 0], Numo::DFloat.ones(8).store(ary).to_a)
+  end
+
+  def test_store_array_shifted_by_conversion
+    shifter = Class.new do
+      def initialize(ary) = @ary = ary
+
+      def to_int
+        4.times { @ary.shift }
+        1
+      end
+    end
+    ary = Array.new(8) { |i| i + 100 }
+    ary[0] = shifter.new(ary)
+
+    assert_equal([1, 105, 106, 107, 0, 0, 0, 0], Numo::Int64.ones(8).store(ary).to_a)
+
+    ary = Array.new(8) { |i| i + 100 }
+    ary[0] = shifter.new(ary)
+    a = Numo::Int64.zeros(16)
+    a[[0, 2, 4, 6, 8, 10, 12, 14]] = ary
+
+    assert_equal([1, 0, 105, 0, 106, 0, 107, 0, 0, 0, 0, 0, 0, 0, 0, 0], a.to_a)
+  end
+
   def test_dfloat_cast_robject
     assert_equal(Numo::DFloat[1, Float::NAN, 3].format_to_a,
                  Numo::DFloat.cast(Numo::RObject[1, nil, 3]).format_to_a)

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -1747,6 +1747,14 @@ class NArrayTest < NArrayTestBase
     assert_equal([1, 0, 105, 0, 106, 0, 107, 0, 0, 0, 0, 0, 0, 0, 0, 0], a.to_a)
   end
 
+  def test_store_array_fills_every_slot_after_a_range
+    assert_equal([9.0, 0.0, 1.0, 5.0], Numo::DFloat.cast([9, (0...2), 5]).to_a)
+    assert_equal([0, 1, 2, 5], Numo::Int64.cast([(0...3), 5]).to_a)
+    assert_equal([1.0, 2.0, 5.0, 7.0], Numo::DFloat.cast([1.step(2, 1), 5, 7]).to_a)
+    assert_equal([0.0, 1.0, 5.0, 0.0], Numo::DFloat.ones(4).store([(0...2), 5]).to_a)
+    assert_equal([1.0, 4.0, 0.0, 0.0], Numo::DFloat.ones(4).store([1, [2, 3], 4]).to_a)
+  end
+
   def test_dfloat_cast_robject
     assert_equal(Numo::DFloat[1, Float::NAN, 3].format_to_a,
                  Numo::DFloat.cast(Numo::RObject[1, nil, 3]).format_to_a)


### PR DESCRIPTION
## Purpose

`iter_*_store_array` is the innermost loop behind `.cast(Array)`, `#store(Array)` and `#[]=`. It holds three separate defects: one that lets a Ruby callback invalidate the pointer the loop is reading from, and two that misplace or skip writes to the destination buffer. The first needs an attacker-supplied object; the other two are reachable from ordinary calls.

## Summary of Changes

One commit per defect.

- **Stale `RARRAY_PTR`.** The loop snapshotted the caller's Array as a raw `VALUE*` before it started, then re-entered Ruby on every element through `m_num_to_data` (`to_f` / `to_int` / `==`) and `nary_step_sequence` (`to_int` on a Range's endpoints). Ruby code run from there can reallocate, shrink or empty the array being read. Each element is now fetched with a bounds check against the current `RARRAY_LEN`, the same guard `loop_store_rarray` already applies one dimension up (`ndloop.c:1599-1604`).
- **`Numo::Bit` stored a Range twice.** `iter_bit_store_array` has the Range branch and the scalar branch as two separate `if`s where the numeric version in `store.h` has `else if`. A Range is not a `T_ARRAY`, so it also went through `m_num_to_data`, which returns 1 for it, and `p1` advanced one bit past what the Range wrote. When the preceding elements fill the last `BIT_DIGIT` exactly, that write lands outside the buffer.
- **The destination counter counted input elements.** `i` advanced once per element of the input Array, but a Range fills `len` slots and a nested Array fills none. The write position tracks the actual writes, so the two drift apart, and the zero fill at `loop_end` stops one slot short per Range — leaving the tail of a freshly allocated buffer untouched and dropping the last input element.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

Six tests added, in `test/test_narray.rb` and `test/test_bit.rb`. Each one was run against a build of `main` without the fix and fails there. Full suite after the change: `103 / 12 / 69 / 29 / 3` runs, 0 failures. AddressSanitizer reports nothing in `test_bit.rb` or `test_extra.rb`; the `ndloop_alloc` report in `test_narray.rb` is unchanged from `main` and carries ASan's own `Memory access ... is inside this variable` line.

```ruby
# 1. Stale pointer: the element's to_int reallocates the array being read.
class Grow
  def to_int
    200.times { $a << 0 }
    1
  end
end
$a = Array.new(8) { |i| i + 100 }
$a[0] = Grow.new
Numo::Int32.cast($a)

# 2. Numo::Bit writes one bit past the buffer.
Numo::Bit.cast([(0...64)])

# 3. Uninitialised tail, no special objects involved.
Numo::DFloat.cast([9, 0...2, 5])
Numo::Int64.cast([(0...3), 5])
Numo::DFloat.cast([1.step(2, 1), 5, 7])
Numo::DFloat.ones(4).store([1, [2, 3], 4])
```

Measured before the fix.

**1. Stale pointer.** The append reallocates the element storage, so the rest of the loop reads freed heap and hands those machine words to `m_num_to_data` as `VALUE`s:

```
[BUG] Segmentation fault at 0x00000000000000ec
c:0004 p:---- s:0016 e:000015 l:y b:0001 CFUNC  :to_int
c:0003 p:---- s:0013 e:000012 l:y b:0001 CFUNC  :cast
flo_to_i numeric.c:2564
```

Shrinking the array reads past its end instead: an element whose `to_int` deletes four entries gave `[1, 105, 106, 107, 107, 107, 107, 107]` from a four-element array, and one that calls `replace([])` gave back `[9.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0]` — the contents of the freed buffer.

**2. `Numo::Bit`.**

```
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7ba3c9c6a9f8
READ of size 4 at 0x7ba3c9c6a9f8 thread T0
    #0 iter_bit_store_array src/t_bit.c:1330
    #1 loop_store_rarray ndloop.c:1621
    #5 bit_store_array src/t_bit.c:1355
    #6 bit_cast_array src/t_bit.c:1566
0x7ba3c9c6a9f8 is located 0 bytes after 8-byte region
```

`STORE_BIT` reads the word it is about to update, so this is a read and a write of the word after the buffer. Below the `BIT_DIGIT` boundary the extra bit only corrupts values: `Numo::Bit.zeros(4).store([(0...2)])` returned `[0, 1, 1, 0]`.

**3. Uninitialised tail.**

```
Numo::DFloat.cast([9, 0...2, 5])           # => [9.0, 0.0, 1.0, -4.637563560477286e+22]
Numo::Int64.cast([(0...3), 5])             # => [0, 1, 2, 0]
Numo::DFloat.cast([1.step(2, 1), 5, 7])    # => [1.0, 2.0, 5.0, 1.24e-322]
Numo::DFloat.ones(4).store([1, [2, 3], 4]) # => [1.0, 4.0, 0.0, 1.0]
```

The last value in each is heap residue rather than the element that belongs there. Under AddressSanitizer it reads back as the `0xbe` fill of a fresh allocation (`Numo::Int64.cast([(0...3), 5])` gave `[0, 1, 2, -4702111234474983746]`), so nothing had written it since `malloc`. `DFloat`, `SFloat`, `Int32`, `Int64` and `Bit` all reproduce it; `RObject` only shows `nil` because its buffer starts out nil-filled.

All three cases return the expected values after the fix, and the AddressSanitizer report is gone.

## Related Issues

None.
