### PR TITLE
Fix out-of-bounds writes in `#bincount` from an overflowing length and a stale scan

### DIFF
--- a/ext/numo/narray/src/mh/bincount.h
+++ b/ext/numo/narray/src/mh/bincount.h
@@ -209,7 +209,11 @@
                                                                                                \
     VALUE v = tDType##_max(0, 0, self);                                                        \
                                                                                                \
-    size_t length = NUM2SIZET(v) + 1;                                                          \
+    const size_t max = NUM2SIZET(v);                                                           \
+    if (max == SIZE_MAX) {                                                                     \
+      rb_raise(rb_eRangeError, "maximum item %" SZF "u is too large to size the output", max); \
+    }                                                                                          \
+    size_t length = max + 1;                                                                   \
     if (opts[0] != Qundef) {                                                                   \
       const size_t minlength = NUM2SIZET(opts[0]);                                             \
       if (minlength > length) {                                                                \

--- a/ext/numo/narray/src/mh/bincount.h
+++ b/ext/numo/narray/src/mh/bincount.h
@@ -1,6 +1,16 @@
 #ifndef NUMO_NARRAY_MH_BINCOUNT_H
 #define NUMO_NARRAY_MH_BINCOUNT_H 1
 
+/* The items below index the output, whose size was fixed by an earlier scan of
+   the same array. Ruby code can run in between, so the bound is rechecked. */
+static inline void na_bincount_check_item(size_t x, size_t n) {
+  if (x >= n) {
+    rb_raise(
+      rb_eIndexError, "item %" SZF "u is out of range of the output(size:%" SZF "u)", x, n
+    );
+  }
+}
+
 #define DEF_BINCOUNT_FUNCS(tDType, tNAryClass)                                                 \
   static void iter_##tDType##_bincount_32(na_loop_t* const lp) {                               \
     char* p1;                                                                                  \
@@ -21,11 +31,13 @@
     if (idx1) {                                                                                \
       for (size_t i = 0; i < m; i++) {                                                         \
         GET_DATA_INDEX(p1, idx1, tDType, x);                                                   \
+        na_bincount_check_item(x, n);                                                          \
         (*(u_int32_t*)(p2 + s2 * x))++;                                                        \
       }                                                                                        \
     } else {                                                                                   \
       for (size_t i = 0; i < m; i++) {                                                         \
         GET_DATA_STRIDE(p1, s1, tDType, x);                                                    \
+        na_bincount_check_item(x, n);                                                          \
         (*(u_int32_t*)(p2 + s2 * x))++;                                                        \
       }                                                                                        \
     }                                                                                          \
@@ -60,11 +72,13 @@
     if (idx1) {                                                                                \
       for (size_t i = 0; i < m; i++) {                                                         \
         GET_DATA_INDEX(p1, idx1, tDType, x);                                                   \
+        na_bincount_check_item(x, n);                                                          \
         (*(u_int64_t*)(p2 + s2 * x))++;                                                        \
       }                                                                                        \
     } else {                                                                                   \
       for (size_t i = 0; i < m; i++) {                                                         \
         GET_DATA_STRIDE(p1, s1, tDType, x);                                                    \
+        na_bincount_check_item(x, n);                                                          \
         (*(u_int64_t*)(p2 + s2 * x))++;                                                        \
       }                                                                                        \
     }                                                                                          \
@@ -106,6 +120,7 @@
     for (size_t i = 0; i < l; i++) {                                                           \
       GET_DATA_STRIDE(p1, s1, tDType, x);                                                      \
       GET_DATA_STRIDE(p2, s2, float, w);                                                       \
+      na_bincount_check_item(x, n);                                                            \
       (*(float*)(p3 + s3 * x)) += w;                                                           \
     }                                                                                          \
   }                                                                                            \
@@ -146,6 +161,7 @@
     for (size_t i = 0; i < l; i++) {                                                           \
       GET_DATA_STRIDE(p1, s1, tDType, x);                                                      \
       GET_DATA_STRIDE(p2, s2, double, w);                                                      \
+      na_bincount_check_item(x, n);                                                            \
       (*(double*)(p3 + s3 * x)) += w;                                                          \
     }                                                                                          \
   }                                                                                            \
@@ -170,6 +186,14 @@
     rb_scan_args(argc, argv, "01:", &weight, &kw);                                             \
     rb_get_kwargs(kw, table, 0, 1, opts);                                                      \
                                                                                                \
+    size_t minlength = 0;                                                                      \
+    if (opts[0] != Qundef) {                                                                   \
+      minlength = NUM2SIZET(opts[0]);                                                          \
+    }                                                                                          \
+    if (!NIL_P(weight) && rb_obj_class(weight) != numo_cSFloat) {                              \
+      weight = rb_funcall(numo_cDFloat, id_cast, 1, weight);                                   \
+    }                                                                                          \
+                                                                                               \
     VALUE v = tDType##_minmax(0, 0, self);                                                     \
     if (m_num_to_data(RARRAY_AREF(v, 0)) < 0) {                                                \
       rb_raise(rb_eArgError, "array items must be non-netagive");                              \
@@ -177,11 +201,8 @@
     v = RARRAY_AREF(v, 1);                                                                     \
                                                                                                \
     size_t length = NUM2SIZET(v) + 1;                                                          \
-    if (opts[0] != Qundef) {                                                                   \
-      const size_t minlength = NUM2SIZET(opts[0]);                                             \
-      if (minlength > length) {                                                                \
-        length = minlength;                                                                    \
-      }                                                                                        \
+    if (minlength > length) {                                                                  \
+      length = minlength;                                                                      \
     }                                                                                          \
                                                                                                \
     if (NIL_P(weight)) {                                                                       \
@@ -207,6 +228,14 @@
     rb_scan_args(argc, argv, "01:", &weight, &kw);                                             \
     rb_get_kwargs(kw, table, 0, 1, opts);                                                      \
                                                                                                \
+    size_t minlength = 0;                                                                      \
+    if (opts[0] != Qundef) {                                                                   \
+      minlength = NUM2SIZET(opts[0]);                                                          \
+    }                                                                                          \
+    if (!NIL_P(weight) && rb_obj_class(weight) != numo_cSFloat) {                              \
+      weight = rb_funcall(numo_cDFloat, id_cast, 1, weight);                                   \
+    }                                                                                          \
+                                                                                               \
     VALUE v = tDType##_max(0, 0, self);                                                        \
                                                                                                \
     const size_t max = NUM2SIZET(v);                                                           \
@@ -214,11 +243,8 @@
       rb_raise(rb_eRangeError, "maximum item %" SZF "u is too large to size the output", max); \
     }                                                                                          \
     size_t length = max + 1;                                                                   \
-    if (opts[0] != Qundef) {                                                                   \
-      const size_t minlength = NUM2SIZET(opts[0]);                                             \
-      if (minlength > length) {                                                                \
-        length = minlength;                                                                    \
-      }                                                                                        \
+    if (minlength > length) {                                                                  \
+      length = minlength;                                                                      \
     }                                                                                          \
                                                                                                \
     if (NIL_P(weight)) {                                                                       \

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -1214,6 +1214,38 @@ class NArrayTest < NArrayTestBase
     assert_raises(RangeError) { Numo::UInt64[(2**64) - 1, (2**62) + 1000].bincount(minlength: 8) }
   end
 
+  def test_bincount_scans_after_converting_its_arguments
+    setter = Class.new do
+      def initialize(array, value)
+        @array = array
+        @value = value
+      end
+
+      def to_int
+        @array[0] = @value
+        3
+      end
+
+      def to_f
+        @array[0] = @value
+        1.0
+      end
+    end
+
+    a = Numo::Int32[0, 1, 2]
+    actual = a.bincount(minlength: setter.new(a, 100_000))
+    assert_equal(100_001, actual.size)
+    assert_equal([1, 1, 1, 3], [actual[100_000], actual[1], actual[2], actual.sum])
+
+    a = Numo::Int32[0, 1, 2]
+    actual = a.bincount([setter.new(a, 100_000), 2.0, 3.0])
+    assert_equal(100_001, actual.size)
+    assert_equal([1.0, 2.0, 3.0], [actual[100_000], actual[1], actual[2]])
+
+    a = Numo::Int32[0, 1, 2]
+    assert_raises(ArgumentError) { a.bincount(minlength: setter.new(a, -1)) }
+  end
+
   def test_2d_narray # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity, Minitest/MultipleAssertions
     TYPES.each do |dtype|
       [[proc { |tp, src| tp[*src] }, ''],

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -1209,6 +1209,11 @@ class NArrayTest < NArrayTestBase
     end
   end
 
+  def test_bincount_rejects_an_item_that_overflows_the_output_length
+    assert_raises(RangeError) { Numo::UInt64[(2**64) - 1].bincount }
+    assert_raises(RangeError) { Numo::UInt64[(2**64) - 1, (2**62) + 1000].bincount(minlength: 8) }
+  end
+
   def test_2d_narray # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity, Minitest/MultipleAssertions
     TYPES.each do |dtype|
       [[proc { |tp, src| tp[*src] }, ''],


### PR DESCRIPTION
## Purpose

The counting kernels behind `#bincount` use each item of the receiver directly as an index into the output buffer. That is only safe while the output length really does cover every item, and two separate paths break it: the length can wrap to 0, and the scan that establishes it can be invalidated by Ruby code before the kernel runs. Both end in a write outside the output.

## Summary of Changes

One commit per defect.

- **The output length wraps.** The unsigned `#bincount` sizes its output as `NUM2SIZET(max) + 1`. An array holding `2**64-1` wraps that to 0. With no output allocated the base pointer is NULL and the increment lands at an address the item chooses; a `minlength:` restores a real allocation and turns it into a controlled offset from it. `RangeError` is now raised when the maximum is `SIZE_MAX`, before the addition. On a 64-bit build only `UInt64` can reach it; on a 32-bit one `UInt32` can too.
- **The scan is stale by the time the kernel runs.** `NUM2SIZET` on the `minlength:` keyword calls `to_int` on it, and passing a Ruby Array as the weight makes `na_ndloop` call `Numo::DFloat.cast` on it, which calls `to_f` on its elements. Both happen after the max / minmax scan, and either callback can write to the receiver. Both arguments are now converted to their final form before the scan, so the callback runs first and the scan sees the array it actually counts — the results become correct rather than merely safe.

The kernels also recheck the bound before each write. That closes the remaining gap, since allocating the output can still run a finalizer, and it keeps the kernels from depending on an invariant established several calls earlier. After the reordering it is not reachable from Ruby, so there is no test for it.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

Two tests added to `test/test_narray.rb`. Both fail against a build of `main` without the fix — the first crashes the process. Full suite after the change: `101 / 9 / 69 / 29 / 3` runs, 0 failures. Every edge case listed below was compared against the unfixed build and is unchanged, including the exception classes and messages.

```ruby
# 1. The output length wraps to 0.
Numo::UInt64[2**64 - 1].bincount
Numo::UInt64[2**64 - 1, 2**62 + 1000].bincount(minlength: 8)

# 2. A conversion callback moves an item past the scanned maximum.
class E
  def initialize(a) = @a = a
  def to_int
    @a[0] = 40
    3
  end
  def to_f
    @a[0] = 40
    1.0
  end
end
a = Numo::Int32[0, 1, 2]
a.bincount(minlength: E.new(a))
a.bincount([E.new(a), 2.0, 3.0])
```

Measured before the fix.

**1. Wrapped length.**

```
Numo::UInt64[2**64 - 1].bincount

[BUG] Segmentation fault at 0x0000000000000000
c:0003 p:---- s:0013 e:000012 l:y b:0001 CFUNC  :bincount
```

With a `minlength:` the process gets further and the write becomes a chosen offset instead:

```
Numo::UInt64[2**64 - 1, 2**62 + 1000].bincount(minlength: 8)
# => Numo::UInt32#shape=[8]
#    [0, 0, 0, 0, 0, 0, 0, 0]
# then SIGSEGV
```

Eight `UInt32` elements are allocated, and the loop evaluates `p2 + 4*(2**62+1000)` modulo `2**64` — 4000 bytes past the output. Neither count reaches the array that was returned.

**2. Stale scan.**

```
ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7bacbfc6ad50
READ of size 4 at 0x7bacbfc6ad50 thread T0
    #0 iter_int32_bincount_32 src/t_int32.c:164
    #1 loop_narray ndloop.c:1236
    #2 ndloop_run ndloop.c:1202
    #5 na_ndloop ndloop.c:1331
    #7 int32_bincount src/t_int32.c:164
```

The scan sees maximum 2 and allocates three `UInt32` elements; the kernel then increments the word at `p2 + 4*40`. With a larger value the same call returned quietly and corrupted memory hundreds of kilobytes away:

```
a = Numo::Int32[0, 1, 2]     # to_int sets a[0] = 100_000
a.bincount(minlength: E.new(a))   # => [0, 1, 1], the count for a[0] written ~400 KB out
a.bincount([E.new(a), 1.0, 1.0])  # => [0, 1, 1], same through the weight path
```

A negative value written by the same callback passes the non-negative check for the same reason and reaches the kernel as a huge `size_t`; that one segfaults outright.

After the fix the callback runs before the scan, so both calls return a `100001`-element result with every item counted in the right bin, and the negative case raises `ArgumentError` from the existing check.

## Related Issues

None.
