### PR TITLE
Fix out-of-bounds access from three unchecked size_t multiplications

### DIFF
--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1275,7 +1275,11 @@ static VALUE nary_s_from_binary(int argc, VALUE* argv, VALUE type) {
       rb_raise(rb_eArgError, "second argument must be size or shape");
     }
     if (FIXNUM_P(velmsz)) {
-      byte_size = len * NUM2SIZET(velmsz);
+      size_t elmsz = NUM2SIZET(velmsz);
+      if (elmsz != 0 && len > SIZE_MAX / elmsz) {
+        rb_raise(rb_eArgError, "specified size is too large");
+      }
+      byte_size = len * elmsz;
     } else {
       byte_size = ceil(len * NUM2DBL(velmsz));
     }
@@ -1341,7 +1345,11 @@ static VALUE nary_store_binary(int argc, VALUE* argv, VALUE self) {
   size = NA_SIZE(na);
   velmsz = rb_const_get(rb_obj_class(self), id_element_byte_size);
   if (FIXNUM_P(velmsz)) {
-    byte_size = size * NUM2SIZET(velmsz);
+    size_t elmsz = NUM2SIZET(velmsz);
+    if (elmsz != 0 && size > SIZE_MAX / elmsz) {
+      rb_raise(rb_eArgError, "string is too short to store");
+    }
+    byte_size = size * elmsz;
   } else {
     byte_size = ceil(size * NUM2DBL(velmsz));
   }

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -311,6 +311,9 @@ void na_setup_shape(narray_t* na, int ndim, size_t* shape) {
   } else {
     for (i = 0, size = 1; i < ndim; i++) {
       na->shape[i] = shape[i];
+      if (shape[i] != 0 && size > SIZE_MAX / shape[i]) {
+        rb_raise(rb_eRangeError, "total number of elements is too large");
+      }
       size *= shape[i];
     }
     na->size = size;

--- a/ext/numo/narray/src/t_dcomplex.c
+++ b/ext/numo/narray/src/t_dcomplex.c
@@ -283,7 +283,7 @@ static VALUE dcomplex_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/ext/numo/narray/src/t_dfloat.c
+++ b/ext/numo/narray/src/t_dfloat.c
@@ -390,7 +390,7 @@ static VALUE dfloat_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/ext/numo/narray/src/t_int16.c
+++ b/ext/numo/narray/src/t_int16.c
@@ -265,7 +265,7 @@ static VALUE int16_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/ext/numo/narray/src/t_int32.c
+++ b/ext/numo/narray/src/t_int32.c
@@ -266,7 +266,7 @@ static VALUE int32_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/ext/numo/narray/src/t_int64.c
+++ b/ext/numo/narray/src/t_int64.c
@@ -265,7 +265,7 @@ static VALUE int64_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/ext/numo/narray/src/t_int8.c
+++ b/ext/numo/narray/src/t_int8.c
@@ -265,7 +265,7 @@ static VALUE int8_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/ext/numo/narray/src/t_robject.c
+++ b/ext/numo/narray/src/t_robject.c
@@ -304,7 +304,7 @@ static VALUE robject_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       {
         size_t i;

--- a/ext/numo/narray/src/t_scomplex.c
+++ b/ext/numo/narray/src/t_scomplex.c
@@ -281,7 +281,7 @@ static VALUE scomplex_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/ext/numo/narray/src/t_sfloat.c
+++ b/ext/numo/narray/src/t_sfloat.c
@@ -388,7 +388,7 @@ static VALUE sfloat_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/ext/numo/narray/src/t_uint16.c
+++ b/ext/numo/narray/src/t_uint16.c
@@ -265,7 +265,7 @@ static VALUE uint16_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/ext/numo/narray/src/t_uint32.c
+++ b/ext/numo/narray/src/t_uint32.c
@@ -265,7 +265,7 @@ static VALUE uint32_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/ext/numo/narray/src/t_uint64.c
+++ b/ext/numo/narray/src/t_uint64.c
@@ -265,7 +265,7 @@ static VALUE uint64_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/ext/numo/narray/src/t_uint8.c
+++ b/ext/numo/narray/src/t_uint8.c
@@ -265,7 +265,7 @@ static VALUE uint8_allocate(VALUE self) {
   case NARRAY_DATA_T:
     ptr = NA_DATA_PTR(na);
     if (na->size > 0 && ptr == NULL) {
-      ptr = xmalloc(sizeof(dtype) * na->size);
+      ptr = xmalloc2(na->size, sizeof(dtype));
 
       NA_DATA_PTR(na) = ptr;
       NA_DATA_OWNED(na) = TRUE;

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2185,6 +2185,13 @@ class NArrayTest < NArrayTestBase
     assert_equal([3, 4], Numo::DFloat.zeros(3, 4).shape)
   end
 
+  def test_allocate_rejects_a_size_whose_byte_count_overflows
+    assert_raises(ArgumentError) { Numo::DFloat.new((2**61) + 4).allocate }
+    assert_raises(ArgumentError) { Numo::DComplex.new((2**60) + 4).allocate }
+    assert_raises(ArgumentError) { Numo::RObject.new((2**61) + 4).allocate }
+    assert_raises(ArgumentError) { Numo::Int32.new((2**62) + 4).seq }
+  end
+
   def test_complex_conj
     [Numo::DComplex, Numo::SComplex].each do |dtype|
       a = dtype[1 + 2i, 3 - 4i, 0 + 0i, -5 + 6i]

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2040,6 +2040,18 @@ class NArrayTest < NArrayTestBase
     assert_equal(Numo::DFloat[4.25], b)
   end
 
+  def test_from_binary_rejects_a_size_whose_byte_count_overflows
+    assert_raises(ArgumentError) { Numo::DFloat.from_binary(+'12345678', 2**61) }
+    assert_raises(ArgumentError) { Numo::DFloat.from_binary('12345678', [2**61]) }
+    assert_raises(ArgumentError) { Numo::DFloat.from_binary('12345678', [2**60, 4]) }
+    assert_raises(ArgumentError) { Numo::Int16.from_binary('12345678', (2**63) + 1) }
+  end
+
+  def test_store_binary_rejects_a_size_whose_byte_count_overflows
+    assert_raises(ArgumentError) { Numo::DFloat.new(2**61).store_binary(('A' * 4096).freeze) }
+    assert_raises(ArgumentError) { Numo::DComplex.new(2**60).store_binary(('A' * 4096).freeze) }
+  end
+
   def test_diagonal
     a = Numo::DFloat[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     assert_equal(Numo::DFloat[1, 5, 9], a.diagonal)

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2175,6 +2175,16 @@ class NArrayTest < NArrayTestBase
     assert_raises(ArgumentError) { Numo::DFloat.new(1, 2, -3) }
   end
 
+  def test_new_rejects_shape_whose_element_count_overflows
+    assert_raises(RangeError) { Numo::Int8.new((2**62) + 1, 4) }
+    assert_raises(RangeError) { Numo::DFloat.new(2**32, 2**32) }
+    assert_raises(RangeError) { Numo::Bit.new((2**62) + 1, 4) }
+    assert_raises(RangeError) { Numo::DFloat.zeros(2**40, 2**40, 2**40) }
+
+    assert_equal(0, Numo::DFloat.new(0, 2**62).size)
+    assert_equal([3, 4], Numo::DFloat.zeros(3, 4).shape)
+  end
+
   def test_complex_conj
     [Numo::DComplex, Numo::SComplex].each do |dtype|
       a = dtype[1 + 2i, 3 - 4i, 0 + 0i, -5 + 6i]


### PR DESCRIPTION
## Purpose

An NArray carries two numbers that must agree: `na->size` (and `na->shape[]`), which every index check is measured against, and the byte count handed to the allocator. Three separate `size_t` multiplications compute one from the other without checking for overflow. When one of them wraps, the object keeps a huge declared extent while owning a tiny buffer, and ordinary element access reads or writes outside it. All three are reachable from plain Ruby with no attacker-supplied object.

## Summary of Changes

One commit per defect.

- **The shape product wraps.** `na_setup_shape` multiplies the per-dimension sizes into `size_t`; only the individual dimensions are checked, and only for being non-negative. `Numo::Int8.new(2**62+1, 4)` gives `size == 4` while `shape` stays `[4611686018427387905, 4]`, so `allocate` reserves 4 bytes and `na_range_check` still measures indices against the huge `shape[0]`. Now raises `RangeError` before the product wraps.
- **The allocator's byte count wraps.** Each `*_allocate` computed `sizeof(dtype) * na->size`. A one-dimensional size never passes through the product above, so this is a second, independent way in: `Numo::DFloat.new(2**61+4)` reserves 32 bytes for an array that claims 2305843009213693956 elements. The 13 typed allocators now use `xmalloc2`, Ruby's own checked multiply. `Numo::Bit` was already safe — it divides before it multiplies.
- **The binary byte count wraps.** `from_binary` sizes its buffer as `len * element_byte_size` and `store_binary` as `na->size * element_byte_size`, both before the `"specified size is too large"` / `"string is too short to store"` guards. When the product wraps those guards compare against a small number and pass. A frozen String then takes `na_set_pointer`, which never allocates, so the checked allocator above does not cover this path. Both now reject the size before multiplying, reusing the existing messages.

The first two fixes do not subsume each other: the shape check does not see a 1-D size, and the allocator check sees the already-wrapped `size`, not the shape it came from.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

Four tests added to `test/test_narray.rb`; all four fail against a build of `main` without the fix. Full suite after the change: `109 / 12 / 69 / 29 / 3` runs, 0 failures. Also built and run against Ruby 3.2.11, 3.3.12, 3.4.9 and 4.0.6 — the exception classes are the same on all four.

```ruby
# 1. The shape product wraps.
a = Numo::Int8.new(2**62 + 1, 4)   # size 4, shape [4611686018427387905, 4]
a.allocate                         # xmalloc(4)
a[2, 0] = 65                       # accepted: 2 < shape[0]

# 2. The allocator's byte count wraps.
a = Numo::DFloat.new(2**61 + 4)    # size 2305843009213693956
a.allocate                         # xmalloc(8 * size) == xmalloc(32)
a[1000] = 1.234

# 3. The binary byte count wraps.
Numo::DFloat.from_binary("12345678", [2**61])[1]
Numo::DFloat.new(2**61).store_binary(("A" * 4096).freeze)[513]
```

Measured before the fix, with AddressSanitizer.

**1. Shape product.**

```
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 1 at 0x7b2c9b6662d8 thread T0
    #0 int8_aset src/t_int8.c:115
```

Four bytes are allocated and the loop evaluates `p + 1*(4*k)`, so any `k` below `2**62+1` is accepted. Without ASan the same call returns quietly.

`Numo::Bit` reaches the same defect through the shared product, one bit per element rather than one byte:

```
a = Numo::Bit.new(2**62 + 1, 4)   # size 4, shape [4611686018427387905, 4]
a.allocate                        # 8 bytes
a[1000, 0] = 1                    # bit 4000

ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 4 at 0x7bf9e8c66264 thread T0
    #0 bit_aset src/t_bit.c:1656
```

Note that a product landing on exactly `2**64` wraps to 0 instead, which leaves an empty array rather than an undersized one; the tests use `2**62+1` so the wrapped size stays non-zero and the access is really out of bounds.

**2. Allocator byte count.**

```
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 8 at 0x7bc246d7db20 thread T0
    #0 dfloat_aset src/t_dfloat.c:168
```

Thirty-two bytes are allocated and the write lands 8000 bytes past them. This one also returns quietly on a normal build.

**3. Binary byte count.**

```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 8 at 0x7bbc65a65ff8 thread T0
    #0 dfloat_aref src/t_dfloat.c:166
```

`byte_size` is `2**61 * 8`, which wraps to 0, so `0 > str_len` is false and the length check passes. The array then claims 2305843009213693952 elements over an 8-byte String. With a frozen String the data pointer is the String's own buffer, so the read discloses whatever follows it; the same happens through `store_binary`.

After the fix all three raise: `RangeError: total number of elements is too large`, `ArgumentError: integer overflow: 2305843009213693956 * 8 > 18446744073709551615` (from `xmalloc2`), and the existing `ArgumentError` messages. Legitimate shapes are unchanged, including zero-sized dimensions such as `Numo::DFloat.new(0, 2**62)`.

## Related Issues

None.
