### PR TITLE
Make the from_binary size test reach the overflow guard

### DIFF
--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2044,7 +2044,7 @@ class NArrayTest < NArrayTestBase
     assert_raises(ArgumentError) { Numo::DFloat.from_binary(+'12345678', 2**61) }
     assert_raises(ArgumentError) { Numo::DFloat.from_binary('12345678', [2**61]) }
     assert_raises(ArgumentError) { Numo::DFloat.from_binary('12345678', [2**60, 4]) }
-    assert_raises(ArgumentError) { Numo::Int16.from_binary('12345678', (2**63) + 1) }
+    assert_raises(ArgumentError) { Numo::Int16.from_binary('12345678', [(2**63) + 1]) }
   end
 
   def test_store_binary_rejects_a_size_whose_byte_count_overflows


### PR DESCRIPTION
## Purpose

One of the tests added in #21 passes for the wrong reason. It is named after the byte-count overflow check that PR introduced, but its input never reaches that check, so the assertion proves nothing about the guard it is meant to cover.

## Summary of Changes

`test_from_binary_rejects_a_size_whose_byte_count_overflows` ends with

```ruby
assert_raises(ArgumentError) { Numo::Int16.from_binary('12345678', (2**63) + 1) }
```

`2**63 + 1` is outside the Fixnum range, so `switch (TYPE(vshape))` in `nary_s_from_binary` does not take the `T_FIXNUM` branch. It falls through to `default:` and raises `"second argument must be size or shape"` — an `ArgumentError`, which is why the assertion is satisfied, but it is raised before `len` is ever multiplied by the element size.

Two-byte elements cannot reach the check through the size form at all: `len * 2` needs `len >= 2**63` to wrap, and a Fixnum stops at `2**62 - 1`. The shape form reaches the same computation with no such limit, so the case becomes `[(2**63) + 1]`. Only that one line changes.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

Full suite: `109 / 12 / 69 / 29 / 3` runs, 0 failures.

```ruby
Numo::Int16.from_binary('12345678', (2**63) + 1)     # before
Numo::Int16.from_binary('12345678', [(2**63) + 1])   # after
```

Measured against `main`, and against a build with `ee40afd` (the guard) reverted:

| input | with the guard | without it |
| --- | --- | --- |
| `(2**63) + 1` | `ArgumentError: second argument must be size or shape` | `ArgumentError: second argument must be size or shape` |
| `[(2**63) + 1]` | `ArgumentError: specified size is too large` | no exception |

Without the guard the shape form returns a `Numo::Int16` reporting `size` 9223372036854775809 whose data pointer is an 8-byte frozen String, which is exactly the state the guard exists to prevent. The size form raises identically either way, so it cannot distinguish the two builds.

Note that the string literal must stay frozen for this to hold: a frozen String takes `na_set_pointer`, which never allocates, so the checked allocator added in the same PR does not mask the difference. `test/test_narray.rb` has `# frozen_string_literal: true`, so the literal is already frozen.

## Related Issues

Follows up #21.
