### PR TITLE
Fix crashes from an unvalidated marshal payload

### DIFF
--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1451,6 +1451,9 @@ static VALUE nary_marshal_load(VALUE self, VALUE a) {
       NUM2INT(RARRAY_AREF(a, 0))
     );
   }
+  if (TYPE(RARRAY_AREF(a, 1)) != T_ARRAY) {
+    rb_raise(rb_eArgError, "marshal shape should be array");
+  }
   na_initialize(self, RARRAY_AREF(a, 1));
   NA_FL0_SET(self, FIX2INT(RARRAY_AREF(a, 2)));
   v = RARRAY_AREF(a, 3);
@@ -1467,6 +1470,7 @@ static VALUE nary_marshal_load(VALUE self, VALUE a) {
     ptr = na_get_pointer_for_write(self);
     memcpy(ptr, RARRAY_PTR(v), NA_SIZE(na) * sizeof(VALUE));
   } else {
+    Check_Type(v, T_STRING);
     rb_str_freeze(v);
     nary_store_binary(1, &v, self);
     if (TEST_BYTE_SWAPPED(self)) {

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2013,6 +2013,29 @@ class NArrayTest < NArrayTestBase
     end
   end
 
+  def test_marshal_load_rejects_a_non_array_shape
+    [42, 'AAAAAAAAAAAAAAAA', nil, {}, 1.5, :abc, true, Object.new].each do |bad|
+      assert_raises(ArgumentError) { Numo::DFloat.allocate.marshal_load([1, bad, 0, +'']) }
+      assert_raises(ArgumentError) { Numo::RObject.allocate.marshal_load([1, bad, 0, []]) }
+    end
+  end
+
+  def test_marshal_load_rejects_non_string_content
+    [[1, 2], {}, Object.new, 12_345, nil, :abc].each do |bad|
+      assert_raises(TypeError) { Numo::DFloat.allocate.marshal_load([1, [2], 0, bad]) }
+    end
+  end
+
+  def test_marshal_load_rejects_a_malformed_stream
+    body = Marshal.dump([1, 42, 0, '']).byteslice(2..)
+    name = 'Numo::DFloat'
+    stream = "\x04\x08U:#{(name.bytesize + 5).chr}#{name}#{body}".b
+    assert_raises(ArgumentError) { Marshal.load(stream) } # rubocop:disable Security/MarshalLoad
+
+    a = Numo::DFloat[1.5, 2.5]
+    assert_equal(a, Marshal.load(Marshal.dump(a)))
+  end
+
   def test_store_binary_to_binary
     (TYPES - [Numo::RObject]).each do |dtype|
       a = dtype[1, 2, 3, 4, 5]


### PR DESCRIPTION
## Purpose

`marshal_load` validates the payload's length and version field and then applies the remaining three elements without checking their types. Two of them reach code that dereferences a `VALUE` as a specific object kind, so a crafted Marshal stream crashes the interpreter inside `Marshal.load`.

## Summary of Changes

The shape is passed to `na_initialize`, which immediately does `RARRAY_LEN` / `RARRAY_AREF` on it, and the data is passed to `rb_str_freeze`, which calls `rb_str_resize`. Neither checks the type first. The shape is now required to be an Array, and the data is `Check_Type`d before either call.

The data element was already type checked one call later, by the `Check_Type` `nary_store_binary` gained in #14. That closed the worst case, where a fabricated String header aimed the array's data pointer at an arbitrary address. `rb_str_freeze` runs before it, though, and returns early for an object that is already frozen, which is why only the unfrozen case still crashed.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

Three tests added to `test/test_narray.rb`. **All three segfault the process against a build of `main` without the fix**, so they are run here one at a time. Full suite after the change: `112 / 12 / 69 / 29 / 3` runs, 0 failures.

```ruby
# 1. A non-Array shape.
Numo::DFloat.allocate.marshal_load([1, 42, 0, ""])

# 2. Unfrozen non-String content.
Numo::DFloat.allocate.marshal_load([1, [2], 0, [1, 2]])

# 3. The same thing through a real Marshal stream, which is how it is reached
#    without calling #marshal_load directly.
body = Marshal.dump([1, 42, 0, ""]).byteslice(2..)
name = "Numo::DFloat"
Marshal.load("\x04\x08U:#{(name.bytesize + 5).chr}#{name}#{body}".b)
```

Measured before the fix.

**1. Non-Array shape.** `RARRAY_LEN` on a Fixnum dereferences the tagged value itself:

```
[BUG] Segmentation fault at 0x0000000000000055
c:0003 p:---- s:0015 e:000014 l:y b:0001 CFUNC  :marshal_load
```

`0x55` is `INT2FIX(42)`. A String, `nil`, `true`, a Symbol, a Float and a Hash all crash the same way at their own addresses. An arbitrary `Object` sometimes survives, reading whatever its instance-variable area happens to hold as a length, which is worse rather than better.

**2. Unfrozen non-String content.**

```
[BUG] Segmentation fault at 0x0000000000000005
```

**3. Through `Marshal.load`.** Same crash, with the frame inside `<internal:marshal>` rather than the caller, confirming that the direct `#marshal_load` call in the first two cases is not what makes this reachable.

After the fix each raises: `ArgumentError: marshal shape should be array` and `TypeError: wrong argument type Array (expected String)`. A legitimate `Marshal.dump` / `Marshal.load` round trip still works, and the existing `marshal_dump` / `marshal_load` round trip over every dtype is unchanged.

## Related Issues

None.
