### PR TITLE
Fix interpreter abort on views of a zero-dimensional NArray

### DIFF
--- a/ext/numo/narray/data.c
+++ b/ext/numo/narray/data.c
@@ -391,7 +391,11 @@ static VALUE na_reshape_bang(int argc, VALUE* argv, VALUE self) {
     } else {
       stridx = na2->stridx;
     }
-    stride = SDX_GET_STRIDE(na2->stridx[na->ndim - 1]);
+    if (na->ndim == 0) {
+      stride = nary_element_stride(self);
+    } else {
+      stride = SDX_GET_STRIDE(na2->stridx[na->ndim - 1]);
+    }
     for (i = argc; i--;) {
       SDX_SET_STRIDE(stridx[i], stride);
       stride *= shape[i];

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -923,6 +923,9 @@ na_check_contiguous(VALUE self) {
     if (NA_VIEW_STRIDX(na) == 0) {
       return Qtrue;
     }
+    if (NA_NDIM(na) == 0) {
+      return Qtrue;
+    }
     if (na_check_ladder(self, 0) == Qtrue) {
       elmsz = nary_element_stride(self);
       if (elmsz == NA_STRIDE_AT(na, NA_NDIM(na) - 1)) {

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -879,6 +879,9 @@ na_check_ladder(VALUE self, int start_dim) {
   narray_t* na;
   GetNArray(self, na);
 
+  if (na->ndim == 0) {
+    return Qtrue;
+  }
   if (start_dim < -na->ndim || start_dim >= na->ndim) {
     rb_bug("start_dim (%d) out of range", start_dim);
   }

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2227,6 +2227,27 @@ class NArrayTest < NArrayTestBase
     assert_raises(ArgumentError) { Numo::Int32.new((2**62) + 4).seq }
   end
 
+  def test_zero_dimensional_view_is_contiguous
+    a = Numo::DFloat.cast(3.5)
+    bin = [3.5].pack('d')
+
+    assert_predicate(a.view, :contiguous?)
+    assert_equal(bin, a.view.to_binary)
+    assert_equal(bin, a.transpose.to_binary)
+    assert_equal(bin, a.flatten.to_binary)
+    assert_equal([1, [], 0, bin], a.view.marshal_dump)
+    assert_equal(a, Marshal.load(Marshal.dump(a.view)))
+
+    assert_equal([1, [], 0, [:sym]], Numo::RObject.cast(:sym).view.marshal_dump)
+  end
+
+  def test_reshape_bang_on_a_zero_dimensional_view
+    a = Numo::DFloat.cast(3.5)
+
+    assert_equal([3.5], a.view.reshape!(1).to_a)
+    assert_equal([[3.5]], a.view.reshape!(1, 1).to_a)
+  end
+
   def test_complex_conj
     [Numo::DComplex, Numo::SComplex].each do |dtype|
       a = dtype[1 + 2i, 3 - 4i, 0 + 0i, -5 + 6i]


### PR DESCRIPTION
## Purpose

Any view of a zero-dimensional NArray aborts the interpreter with `[BUG] start_dim (0) out of range`. `na_check_contiguous` asks `na_check_ladder(self, 0)` whether the view is a ladder, and that function's range check (`start_dim < -ndim || start_dim >= ndim`) rejects every possible `start_dim` when `ndim` is 0, so it reaches `rb_bug` and the process dies with SIGABRT.

Six public methods reach it: `#contiguous?`, `#to_binary`, `#to_string`, `#marshal_dump`, `Marshal.dump` and `#reshape!`. Views of a zero-dimensional array are easy to produce — `#view`, `#transpose` and `#flatten` all return one.

## Summary of Changes

- Return `Qtrue` from `na_check_contiguous` for a zero-dimensional view: it holds a single element, so there is no stride to compare.
- Use the element stride in `na_reshape_bang` when `ndim` is 0. That line read `stridx[na->ndim - 1]`, an out-of-bounds read that the `rb_bug` above was masking; ASan reports it as an 8-byte heap over-read once the first fix is applied.
- Return `Qtrue` from `na_check_ladder` itself for a zero-dimensional array, in a second commit. `nary_check_ladder` is exported in `narray.def`, so an external extension can reach the same `rb_bug` even after the caller above is fixed. Note that the range check cannot simply be relaxed in place — falling through with `ndim` 0 would read `stridx[0]` in the `NARRAY_VIEW_T` branch.
- Add tests covering both reachable paths. There is no Ruby-level test for the third commit: with `na_check_contiguous` fixed, no path from Ruby reaches `na_check_ladder` with `ndim` 0 (`na_flatten_dim` returns early for `nd == 0`). It is there for callers outside this gem.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

Both new tests abort the interpreter on the current `main` build and pass after the change. With only the `narray.c` half applied, `reshape!` reproduces as a heap over-read under `-fsanitize=address`:

```
==37876==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b57e0c66008
READ of size 8 at 0x7b57e0c66008 thread T0
    #0 na_reshape_bang ext/numo/narray/data.c:394
0x7b57e0c66008 is located 8 bytes before 1-byte region [0x7b57e0c66010,0x7b57e0c66011)
```

```ruby
a = Numo::DFloat.cast(3.5)

a.view.contiguous?      # [BUG] start_dim (0) out of range -> now true
a.view.to_binary        # [BUG] -> now "\x00\x00\x00\x00\x00\x00\f@"
a.transpose.to_binary   # [BUG] -> now "\x00\x00\x00\x00\x00\x00\f@"
a.flatten.to_binary     # [BUG] -> now "\x00\x00\x00\x00\x00\x00\f@"
Marshal.dump(a.view)    # [BUG] -> now round-trips
a.view.reshape!(1).to_a # [BUG] -> now [3.5]
```

## Related Issues

None.
