### PR TITLE
Fix out-of-bounds reads from view offsets in `to_binary` and `marshal_dump`

### DIFF
--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1415,7 +1415,7 @@ static VALUE nary_marshal_dump(VALUE self) {
     GetNArray(self, na);
     if (na->type == NARRAY_VIEW_T) {
       if (na_check_contiguous(self) == Qtrue) {
-        offset = NA_VIEW_OFFSET(na);
+        offset = NA_VIEW_OFFSET(na) / sizeof(VALUE);
       } else {
         self = rb_funcall(self, id_dup, 0);
       }

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1378,10 +1378,12 @@ static VALUE nary_to_binary(VALUE self) {
   char* ptr;
   VALUE str;
   narray_t* na;
+  int offset_in_bits;
 
   GetNArray(self, na);
   if (na->type == NARRAY_VIEW_T) {
-    if (na_check_contiguous(self) == Qtrue) {
+    offset_in_bits = RTEST(rb_obj_is_kind_of(self, numo_cBit)) && NA_VIEW_OFFSET(na) != 0;
+    if (!offset_in_bits && na_check_contiguous(self) == Qtrue) {
       offset = NA_VIEW_OFFSET(na);
     } else {
       self = rb_funcall(self, id_dup, 0);

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -3,6 +3,8 @@
 require_relative 'test_helper'
 
 class NArrayTest < NArrayTestBase
+  class BitSubclass < Numo::Bit; end
+
   def test_inheritance_relationship
     TYPES.each do |dtype|
       assert_operator(dtype, :<, Numo::NArray)
@@ -2011,6 +2013,29 @@ class NArrayTest < NArrayTestBase
       restored.marshal_load(dump_data)
       assert_equal(original, restored)
     end
+  end
+
+  def test_to_binary_of_a_bit_view_with_an_offset
+    bits = Array.new(200) { |i| (i * 7 % 5).zero? ? 1 : 0 }
+
+    a = Numo::Bit.cast(bits)
+
+    [0, 1, 3, 8, 11, 16, 63, 64, 65, 100].each do |i|
+      v = a[i..(i + 20)]
+      assert_equal(bits[i, 21], v.to_a)
+      assert_equal(v.to_a, Marshal.load(Marshal.dump(v)).to_a)
+      assert_equal(v.to_a.join, v.to_binary.unpack1('b*')[0, 21])
+    end
+  end
+
+  def test_to_binary_of_a_bit_subclass_view_with_an_offset
+    bits = Array.new(32) { |i| (i % 3).zero? ? 1 : 0 }
+    a = BitSubclass.new(32).store(Numo::Bit.cast(bits))
+
+    assert_equal(bits, a.to_a)
+    assert_equal(bits.join, a.to_binary.unpack1('b*'))
+    assert_equal(bits[8, 8], a[8..15].to_a)
+    assert_raises(Numo::NArray::CastError) { a[8..15].to_binary }
   end
 
   def test_marshal_load_rejects_a_non_array_shape

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2015,6 +2015,16 @@ class NArrayTest < NArrayTestBase
     end
   end
 
+  def test_marshal_dump_of_a_robject_view_with_an_offset
+    a = Numo::RObject.cast(%i[a b c d e f g h])
+
+    (0..5).each do |i|
+      v = a[i..(i + 2)]
+      assert_equal([1, [3], 0, v.to_a], v.marshal_dump)
+      assert_equal(v.to_a, Marshal.load(Marshal.dump(v)).to_a)
+    end
+  end
+
   def test_to_binary_of_a_bit_view_with_an_offset
     bits = Array.new(200) { |i| (i * 7 % 5).zero? ? 1 : 0 }
 


### PR DESCRIPTION
## Purpose

`nary_to_binary` and `nary_marshal_dump` take a shortcut for contiguous views: instead of copying, they add `NA_VIEW_OFFSET` to the data pointer. That assumes the stored offset is a byte offset into a `char*`. Two classes break the assumption, and both read outside the allocation.

- **`Numo::Bit`** declares `element_stride` in **bits** (`src/t_bit.c:480`), so its view offset counts bits. `nary_to_binary` adds it to a `char*` as if it were bytes.
- **`Numo::RObject`** stores a byte offset, but `nary_marshal_dump` adds it to a `VALUE*`, so the pointer advances eight times too far.

Neither is a regression; both reproduce on `main` (`66d49f6`). A view starting at index 0 is unaffected, which is why the existing marshal tests pass.

## Summary of Changes

- Copy a `Numo::Bit` view instead of taking the in-place path when its offset is non-zero. A zero offset is already correct, and every other dtype keeps the shortcut. The test is `rb_obj_is_kind_of` rather than the `rb_obj_class(x) == numo_cFoo` used elsewhere in the file, because a subclass slipping through this particular check reads out of bounds rather than falling back to a generic path.
- Divide by `sizeof(VALUE)` before advancing the `VALUE*` in `nary_marshal_dump`.
- Add tests for both, covering aligned and unaligned bit offsets and every starting index of an `RObject` view.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

Both new tests fail on `main` — the `Numo::Bit` one as a wrong value, the `Numo::RObject` one by killing the process. Under `-fsanitize=address` the `Numo::Bit` case is an out-of-bounds read:

```
==69531==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b595dc660b8
    #0 memcpy
    #2 ruby_nonempty_memcpy include/ruby/internal/memory.h:759
0x7b595dc660b8 is located 4 bytes after 4-byte region [0x7b595dc660b0,0x7b595dc660b4)
```

```ruby
a = Numo::Bit.cast(Array.new(32) { |i| (i % 3).zero? ? 1 : 0 })
v = a[8..15]
v.to_a                              # => [0, 1, 0, 0, 1, 0, 0, 1]
Marshal.load(Marshal.dump(v)).to_a  # before: [0, 0, 0, 0, 0, 0, 0, 0]
                                    # after:  [0, 1, 0, 0, 1, 0, 0, 1]

b = Numo::RObject.cast(%i[a b c d e])
Marshal.dump(b[1..3])               # before: SIGSEGV
                                    # after:  round-trips to [:b, :c, :d]
```

A subclass of `Numo::Bit` was reading out of bounds the same way, so the copy path now covers it too. That copy currently raises `Numo::NArray::CastError`, because no `Numo::*` subclass can be duplicated yet — `MyF.new(2, 3).seq[0..1, 0..1].to_binary` already raises the same error on `main` through the pre-existing `dup` fallback. Replacing an out-of-bounds read with the error every other subclass already gets seemed like the right trade; fixing subclass `#store` is a separate matter.

## Related Issues

None.
