### PR TITLE
Fix out-of-bounds reads from state changed before validation

### DIFF
--- a/ext/numo/narray/data.c
+++ b/ext/numo/narray/data.c
@@ -359,6 +359,10 @@ static void na_check_reshape(int argc, VALUE* argv, VALUE self, size_t* shape) {
   } else if (total != NA_SIZE(na)) {
     rb_raise(rb_eArgError, "Total size must be same");
   }
+
+  if (argc > NA_MAX_DIMENSION) {
+    rb_raise(nary_eDimensionError, "ndim=%d is too many", argc);
+  }
 }
 
 /*

--- a/ext/numo/narray/data.c
+++ b/ext/numo/narray/data.c
@@ -377,6 +377,9 @@ static VALUE na_reshape_bang(int argc, VALUE* argv, VALUE self) {
   stridx_t* stridx;
   int i;
 
+  if (OBJ_FROZEN(self)) {
+    rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
+  }
   if (na_check_contiguous(self) == Qfalse) {
     rb_raise(rb_eStandardError, "cannot change shape of non-contiguous NArray");
   }

--- a/ext/numo/narray/data.c
+++ b/ext/numo/narray/data.c
@@ -380,6 +380,7 @@ static VALUE na_reshape_bang(int argc, VALUE* argv, VALUE self) {
   ssize_t stride;
   stridx_t* stridx;
   int i;
+  VALUE tmp;
 
   if (OBJ_FROZEN(self)) {
     rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
@@ -387,7 +388,7 @@ static VALUE na_reshape_bang(int argc, VALUE* argv, VALUE self) {
   if (na_check_contiguous(self) == Qfalse) {
     rb_raise(rb_eStandardError, "cannot change shape of non-contiguous NArray");
   }
-  shape = ALLOCA_N(size_t, argc);
+  shape = RB_ALLOCV_N(size_t, tmp, argc);
   na_check_reshape(argc, argv, self, shape);
 
   GetNArray(self, na);
@@ -413,6 +414,7 @@ static VALUE na_reshape_bang(int argc, VALUE* argv, VALUE self) {
     }
   }
   na_setup_shape(na, argc, shape);
+  RB_ALLOCV_END(tmp);
   return self;
 }
 
@@ -427,14 +429,15 @@ static VALUE na_reshape_bang(int argc, VALUE* argv, VALUE self) {
 static VALUE na_reshape(int argc, VALUE* argv, VALUE self) {
   size_t* shape;
   narray_t* na;
-  VALUE copy;
+  VALUE copy, tmp;
 
-  shape = ALLOCA_N(size_t, argc);
+  shape = RB_ALLOCV_N(size_t, tmp, argc);
   na_check_reshape(argc, argv, self, shape);
 
   copy = rb_funcall(self, rb_intern("dup"), 0);
   GetNArray(copy, na);
   na_setup_shape(na, argc, shape);
+  RB_ALLOCV_END(tmp);
   return copy;
 }
 

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -276,6 +276,13 @@ void na_array_to_internal_shape(VALUE self, VALUE ary, size_t* shape) {
 }
 
 void na_alloc_shape(narray_t* na, int ndim) {
+  if (ndim < 0) {
+    rb_raise(nary_eDimensionError, "ndim=%d is negative", ndim);
+  }
+  if (ndim > NA_MAX_DIMENSION) {
+    rb_raise(nary_eDimensionError, "ndim=%d is too many", ndim);
+  }
+
   na->ndim = ndim;
   na->size = 0;
   if (na->shape != NULL && na->shape != &(na->size)) {
@@ -288,12 +295,6 @@ void na_alloc_shape(narray_t* na, int ndim) {
     na->shape = &(na->size);
     break;
   default:
-    if (ndim < 0) {
-      rb_raise(nary_eDimensionError, "ndim=%d is negative", ndim);
-    }
-    if (ndim > NA_MAX_DIMENSION) {
-      rb_raise(nary_eDimensionError, "ndim=%d is too many", ndim);
-    }
     na->shape = ALLOC_N(size_t, ndim);
   }
 }

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -275,13 +275,17 @@ void na_array_to_internal_shape(VALUE self, VALUE ary, size_t* shape) {
   }
 }
 
-void na_alloc_shape(narray_t* na, int ndim) {
+static void na_check_ndim(int ndim) {
   if (ndim < 0) {
     rb_raise(nary_eDimensionError, "ndim=%d is negative", ndim);
   }
   if (ndim > NA_MAX_DIMENSION) {
     rb_raise(nary_eDimensionError, "ndim=%d is too many", ndim);
   }
+}
+
+void na_alloc_shape(narray_t* na, int ndim) {
+  na_check_ndim(ndim);
 
   na->ndim = ndim;
   na->size = 0;
@@ -303,22 +307,23 @@ void na_setup_shape(narray_t* na, int ndim, size_t* shape) {
   int i;
   size_t size;
 
+  na_check_ndim(ndim);
+
+  for (i = 0, size = 1; i < ndim; i++) {
+    if (shape[i] != 0 && size > SIZE_MAX / shape[i]) {
+      rb_raise(rb_eRangeError, "total number of elements is too large");
+    }
+    size *= shape[i];
+  }
+
   na_alloc_shape(na, ndim);
 
-  if (ndim == 0) {
-    na->size = 1;
-  } else if (ndim == 1) {
-    na->size = shape[0];
-  } else {
-    for (i = 0, size = 1; i < ndim; i++) {
+  if (ndim > 1) {
+    for (i = 0; i < ndim; i++) {
       na->shape[i] = shape[i];
-      if (shape[i] != 0 && size > SIZE_MAX / shape[i]) {
-        rb_raise(rb_eRangeError, "total number of elements is too large");
-      }
-      size *= shape[i];
     }
-    na->size = size;
   }
+  na->size = (ndim == 0) ? 1 : size;
 }
 
 static void na_setup(VALUE self, int ndim, size_t* shape) {

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1451,6 +1451,9 @@ static VALUE na_inplace(VALUE self);
 static VALUE nary_marshal_load(VALUE self, VALUE a) {
   VALUE v;
 
+  if (OBJ_FROZEN(self)) {
+    rb_raise(rb_eRuntimeError, "cannot write to frozen NArray.");
+  }
   if (TYPE(a) != T_ARRAY) {
     rb_raise(rb_eArgError, "marshal argument should be array");
   }

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2180,6 +2180,14 @@ class NArrayTest < NArrayTestBase
     assert_equal(fits, Numo::DFloat.new(1).seq.reshape!(*fits).shape)
   end
 
+  def test_reshape_bang_with_a_large_argument_list
+    a = Numo::DFloat.new(1).seq
+
+    assert_raises(Numo::NArray::DimensionError) { a.reshape!(*([1] * 1_000)) }
+    assert_equal([1], a.shape)
+    assert_equal([0.0], a.to_a)
+  end
+
   def test_setup_shape_leaves_the_array_untouched_when_the_element_count_overflows
     a = Numo::DFloat.new(2).seq
 

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2159,6 +2159,16 @@ class NArrayTest < NArrayTestBase
     assert_raises(ArgumentError) { Numo::DFloat.new(6).seq.reshape(2**30, 2**30, 16, nil) }
   end
 
+  def test_reshape_bang_leaves_the_array_untouched_when_it_raises
+    a = Numo::DFloat.new(1).seq
+
+    assert_raises(Numo::NArray::DimensionError) { a.reshape!(*([1] * 63)) }
+    assert_equal([1], a.shape)
+    assert_equal([0.0], a.to_a)
+
+    assert_equal([1] * 62, a.reshape!(*([1] * 62)).shape)
+  end
+
   def test_reshape_unfixed_dimension
     a = Numo::DFloat.new(6).seq
     assert_equal([2, 3], a.reshape(2, nil).shape)

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2200,6 +2200,17 @@ class NArrayTest < NArrayTestBase
     end
   end
 
+  def test_marshal_load_rejects_a_frozen_narray
+    a = Numo::DFloat.new(2).seq.freeze
+    data = Numo::DFloat.new(4, 5).seq.marshal_dump
+
+    err = assert_raises(RuntimeError) { a.marshal_load(data) }
+    assert_match(/frozen/, err.message)
+    assert_equal([2], a.shape)
+    assert_equal(2, a.size)
+    assert_equal([0.0, 1.0], a.to_a)
+  end
+
   def test_reshape_unfixed_dimension
     a = Numo::DFloat.new(6).seq
     assert_equal([2, 3], a.reshape(2, nil).shape)

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2160,13 +2160,24 @@ class NArrayTest < NArrayTestBase
   end
 
   def test_reshape_bang_leaves_the_array_untouched_when_it_raises
-    a = Numo::DFloat.new(1).seq
+    max_dimension = ([0].pack('J').bytesize * 8) - 2
+    ones = [1] * (max_dimension + 1)
+    padded = [2, 3] + ones.first(max_dimension - 1)
 
-    assert_raises(Numo::NArray::DimensionError) { a.reshape!(*([1] * 63)) }
-    assert_equal([1], a.shape)
-    assert_equal([0.0], a.to_a)
+    [Numo::DFloat.new(1).seq, Numo::DFloat.new(3).seq[1..1]].each do |a|
+      assert_raises(Numo::NArray::DimensionError) { a.reshape!(*ones) }
+      assert_equal([1], a.shape)
+      assert_equal([a[0]], a.to_a)
+    end
 
-    assert_equal([1] * 62, a.reshape!(*([1] * 62)).shape)
+    [Numo::DFloat.new(6).seq, Numo::DFloat.new(6).seq[0..5]].each do |a|
+      assert_raises(Numo::NArray::DimensionError) { a.reshape!(*padded) }
+      assert_equal([6], a.shape)
+      assert_equal([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], a.to_a)
+    end
+
+    fits = [1] * max_dimension
+    assert_equal(fits, Numo::DFloat.new(1).seq.reshape!(*fits).shape)
   end
 
   def test_setup_shape_leaves_the_array_untouched_when_the_element_count_overflows

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2169,6 +2169,15 @@ class NArrayTest < NArrayTestBase
     assert_equal([1] * 62, a.reshape!(*([1] * 62)).shape)
   end
 
+  def test_setup_shape_leaves_the_array_untouched_when_the_element_count_overflows
+    a = Numo::DFloat.new(2).seq
+
+    assert_raises(RangeError) { a.marshal_load([1, [2**40, 2**40, 8], 0, +'']) }
+    assert_equal([2], a.shape)
+    assert_equal(2, a.size)
+    assert_equal([0.0, 1.0], a.to_a)
+  end
+
   def test_reshape_bang_rejects_a_frozen_narray
     views = [Numo::DFloat.new(2, 3).seq.freeze, Numo::DFloat.new(6).seq.reshape(2, 3)[0..1, 0..2].freeze]
 

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2169,6 +2169,17 @@ class NArrayTest < NArrayTestBase
     assert_equal([1] * 62, a.reshape!(*([1] * 62)).shape)
   end
 
+  def test_reshape_bang_rejects_a_frozen_narray
+    views = [Numo::DFloat.new(2, 3).seq.freeze, Numo::DFloat.new(6).seq.reshape(2, 3)[0..1, 0..2].freeze]
+
+    views.each do |a|
+      err = assert_raises(RuntimeError) { a.reshape!(6) }
+      assert_match(/frozen/, err.message)
+      assert_equal([2, 3], a.shape)
+      assert_equal([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], a.to_a)
+    end
+  end
+
   def test_reshape_unfixed_dimension
     a = Numo::DFloat.new(6).seq
     assert_equal([2, 3], a.reshape(2, nil).shape)


### PR DESCRIPTION
## Purpose

Five places where `#reshape!` and `#marshal_load` change an array before deciding the change is legal, so a raise leaves the array describing memory it does not own.

- `na_alloc_shape` assigned `na->ndim` before checking it. A 1-D array keeps `shape` pointing at `&na->size`, so `#shape` then read `ndim` words past the `narray_t`.
- `na_setup_shape` ran its overflow guard inside the loop already writing `na->shape`, leaving the tail of a fresh `ALLOC_N` visible as Integers.
- `na_reshape_bang` replaced `na2->stridx` before the dimension count was checked, so a view kept the new strides over the old shape.
- `#reshape!` and `#marshal_load` never asked for a writable pointer, so both skipped the `OBJ_FROZEN` guard every other mutating method gets.
- `na_reshape_bang` and `na_reshape` ran `ALLOCA_N` on the splat length before anything validated it, so a large enough argument list walked off the thread stack.

None is a regression; all reproduce on `main` (`66d49f6`).

## Summary of Changes

- Validate `ndim`, the element count and the reshape argument count before anything is written.
- Raise on a frozen receiver in `na_reshape_bang` and `nary_marshal_load`, same class and message as the rest of the file.
- Swap `ALLOCA_N` for `RB_ALLOCV_N`, which keeps the alloca for ordinary calls and moves large ones to the heap. Already used in `src/mh/sort.h`.
- One commit per defect, one test each.
- Error classes, messages and precedence are unchanged: the new `ndim` check goes last in `na_check_reshape`, and `ndim` values of 0 and 1 never reached the branch that was hoisted.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

Each new test fails on `main`, and all four reads are clean under `-fsanitize=address` afterwards.

```ruby
a = Numo::DFloat.new(1).seq
a.reshape!(*([1] * 63)) rescue nil       # before: shape.size 63, heap addresses
                                         # after:  [1]
v = Numo::DFloat.new(6).seq[0..5]
v.reshape!(2, 3, *([1] * 61)) rescue nil # before: to_a [0.0, 3.0, 8.4e-314, ...]
                                         # after:  [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
b = Numo::DFloat.new(2).seq
b.marshal_load([1, [2**40, 2**40, 8], 0, '']) rescue nil
                                         # before: shape [2**40, 2**40, <pointer>]
                                         # after:  [2]
c = Numo::DFloat.new(2).seq.freeze
c.marshal_load(Numo::DFloat.new(4, 5).seq.marshal_dump) rescue nil
                                         # before: shape [4, 5] over 16 bytes
                                         # after:  RuntimeError, [2]
Numo::DFloat.new(2, 3).seq.freeze.reshape!(6)   # before: succeeded
```

The stack case needs a thread rather than the main thread, and reproduces on `main` as well:

```
RUBY_THREAD_VM_STACK_SIZE=4194304 ruby -e 'require "numo/narray"
  a = Numo::DFloat.new(1).seq
  Thread.new { a.reshape!(*([1] * 200_000)) }.value'
# before: [BUG] Segmentation fault, CFUNC :reshape!
# after:  Numo::NArray::DimensionError
```

## Related Issues

None.
