### PR TITLE
Fix out-of-bounds reads when storing a Ruby Array of NArrays

### DIFF
--- a/ext/numo/narray/ndloop.c
+++ b/ext/numo/narray/ndloop.c
@@ -520,7 +520,7 @@ static void ndloop_set_stepidx(na_md_loop_t* lp, int j, VALUE vna, int* dim_map,
       if (n > 1 || nd > 0) {
         i = dim_map[k];
         LITER(lp, i, j).step = s;
-        // LITER(lp,i,j).idx = NULL;
+        LITER(lp, i, j).idx = NULL;
       }
       s *= n;
       nd--;
@@ -539,7 +539,7 @@ static void ndloop_set_stepidx(na_md_loop_t* lp, int j, VALUE vna, int* dim_map,
           LITER(lp, i, j).idx = SDX_GET_INDEX(sdx);
         } else {
           LITER(lp, i, j).step = SDX_GET_STRIDE(sdx);
-          // LITER(lp,i,j).idx = NULL;
+          LITER(lp, i, j).idx = NULL;
         }
       } else if (n == 1) {
         if (SDX_IS_INDEX(sdx)) {

--- a/ext/numo/narray/ndloop.c
+++ b/ext/numo/narray/ndloop.c
@@ -1540,6 +1540,7 @@ static void loop_store_subnarray(ndfunc_t* nf, na_md_loop_t* lp, int i0, size_t*
     dim_map[i] = lp->trans_map[i + i0];
   }
   ndloop_set_stepidx(lp, 1, a, dim_map, NDL_READ);
+  LITER(lp, i0, 1).pos = LITER(lp, 0, 1).pos;
   LARG(lp, 1).shape = &(na->shape[na->ndim - 1]);
 
   // loop body

--- a/ext/numo/narray/src/mh/store.h
+++ b/ext/numo/narray/src/mh/store.h
@@ -165,8 +165,13 @@ static inline bool na_store_rary_fetch(VALUE ary, size_t i, VALUE* x) {
     i = 0;                                                                                     \
     if (lp->args[1].ptr) {                                                                     \
       if (v1 == Qtrue) {                                                                       \
-        iter_##tDType##_store_##tDType(lp);                                                    \
         i = lp->args[1].shape[0];                                                              \
+        if (i > n) {                                                                           \
+          i = n;                                                                               \
+        }                                                                                      \
+        NDL_CNT(lp) = i;                                                                       \
+        iter_##tDType##_store_##tDType(lp);                                                    \
+        NDL_CNT(lp) = n;                                                                       \
         if (idx1) {                                                                            \
           idx1 += i;                                                                           \
         } else {                                                                               \

--- a/ext/numo/narray/src/t_bit.c
+++ b/ext/numo/narray/src/t_bit.c
@@ -1270,8 +1270,13 @@ static void iter_bit_store_array(na_loop_t* const lp) {
 
   if (lp->args[1].ptr) {
     if (v1 == Qtrue) {
-      iter_bit_store_bit(lp);
       i = lp->args[1].shape[0];
+      if (i > n) {
+        i = n;
+      }
+      NDL_CNT(lp) = i;
+      iter_bit_store_bit(lp);
+      NDL_CNT(lp) = n;
       if (idx1) {
         idx1 += i;
       } else {

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -511,6 +511,12 @@ class NArrayTest < NArrayTestBase
     end
   end
 
+  def test_store_does_not_reuse_the_index_of_a_previous_sub_narray
+    src = Numo::Int32.new(1000).seq
+    rows = [src[[999, 998, 997, 996, 995, 994, 993, 992]], Numo::Int32.new(8).seq]
+    assert_equal([rows[0].to_a, rows[1].to_a], Numo::Int32.zeros(2, 8).store(rows).to_a)
+  end
+
   def test_cast
     a = 10
     TYPES.each do |stype|

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -536,6 +536,22 @@ class NArrayTest < NArrayTestBase
     assert_equal([brows[0].to_a, brows[1].to_a], Numo::Bit.new(2, 8).store(brows).to_a)
   end
 
+  def test_store_of_a_sub_narray_shorter_than_the_row
+    want = [[1, 2, 3, 0, 0, 0, 0, 0], [4, 5, 6, 0, 0, 0, 0, 0]]
+    a = Numo::Int32.new(2, 8).fill(9)
+    a.store([Numo::Int32[1, 2, 3], Numo::Int32[4, 5, 6]])
+    assert_equal(want, a.to_a)
+    assert_equal(want, Numo::Int32.new(2, 8).fill(9).store([[1, 2, 3], [4, 5, 6]]).to_a)
+
+    src = Numo::Int32.new(4, 300).seq.gt(100)
+    rows = [src[0, 0...64], src[1, [3, 1, 2, 0]], src[2, true]]
+    b = Numo::Bit.new(3, 300).fill(1)
+    b.store(rows)
+    assert_equal(rows[0].to_a + ([0] * 236), b[0, true].to_a)
+    assert_equal(rows[1].to_a + ([0] * 296), b[1, true].to_a)
+    assert_equal(rows[2].to_a, b[2, true].to_a)
+  end
+
   def test_cast
     a = 10
     TYPES.each do |stype|

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -511,10 +511,29 @@ class NArrayTest < NArrayTestBase
     end
   end
 
+  def test_store_keeps_the_offset_of_each_sub_narray
+    TYPES.each do |dtype|
+      src = dtype.new(2, 8).seq
+      rows = [src[1, true], src[0, true]]
+      want = [rows[0].to_a, rows[1].to_a]
+      assert_equal(want, dtype.zeros(2, 8).store(rows).to_a)
+      assert_equal(want, dtype.cast(rows).to_a)
+      assert_equal(want, dtype[*rows].to_a)
+    end
+
+    bits = Numo::Int32.new(2, 8).seq.gt(3)
+    brows = [bits[1, true], bits[0, true]]
+    assert_equal([brows[0].to_a, brows[1].to_a], Numo::Bit.cast(brows).to_a)
+  end
+
   def test_store_does_not_reuse_the_index_of_a_previous_sub_narray
     src = Numo::Int32.new(1000).seq
     rows = [src[[999, 998, 997, 996, 995, 994, 993, 992]], Numo::Int32.new(8).seq]
     assert_equal([rows[0].to_a, rows[1].to_a], Numo::Int32.zeros(2, 8).store(rows).to_a)
+
+    bits = Numo::Int32.new(2, 8).seq.gt(3)
+    brows = [bits[0, [7, 6, 5, 4, 3, 2, 1, 0]], bits[1, true]]
+    assert_equal([brows[0].to_a, brows[1].to_a], Numo::Bit.new(2, 8).store(brows).to_a)
   end
 
   def test_cast


### PR DESCRIPTION
## Purpose

`#store` with a Ruby Array of NArrays reused one iterator slot for every sub-narray without resetting it, and read each sub-narray to the destination's row length instead of its own. The result was silently wrong values for any sub-narray that was already the destination's class, and out-of-bounds reads that segfault.

## Summary of Changes

- Clear `.idx` in `ndloop_set_stepidx()` so an index-backed sub-narray does not leave its index vector behind for the next one.
- Seed the position chain at `LITER(lp, i0, 1)` in `loop_store_subnarray()`, so each sub-narray's view offset reaches the slot the kernel reads.
- Clamp the count handed to the nested store in `iter_<T>_store_array()` to the sub-narray's length, so a short sub-narray is not read past its end. The remainder still reaches the zero fill at `loop_end`, which is what a short Ruby Array row already gets.
- Add three regression tests.

`#store`, `.cast`, `[]` and `#[]=` all reach this path. The sub-narray is cast when its class differs from the destination and the cast result is contiguous, so the first two defects only surface once the classes already match.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

238 runs / 0 failures, and no findings from this path under AddressSanitizer. A randomised differential test (3000 iterations, 3 rows drawn from 6 sub-narray kinds and 5 lengths, compared against a per-row reference) reports 0 mismatches; the same script core-dumps on `5948c8e` at its first iteration.

On what each test actually catches: the first two fail on `5948c8e` on value assertions, and the second reads out of bounds under ASan there. For the third, the `Numo::Bit` half segfaults on the build without its fix, but **the `Numo::Int32` half passes there** -- the zero fill at `loop_end` overwrites whatever the over-read produced, so that half locks in the semantics rather than detecting the defect. Its over-read is visible only under ASan.

```ruby
require 'numo/narray'

src = Numo::Int32.new(2, 8).seq

# the offset of every sub-narray was dropped
p Numo::Int32.zeros(2, 8).store([src[1, true], src[0, true]]).to_a
# before => [[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7]]
# after  => [[8, 9, 10, 11, 12, 13, 14, 15], [0, 1, 2, 3, 4, 5, 6, 7]]

# an index-backed sub-narray leaked its index vector into the next one
p Numo::Int32.zeros(2, 8).store([src[0, [7, 6, 5, 4, 3, 2, 1, 0]], src[1, true]]).to_a
# before => [[7, 6, 5, 4, 3, 2, 1, 0], [7, 6, 5, 4, 3, 2, 1, 0]]
# after  => [[7, 6, 5, 4, 3, 2, 1, 0], [8, 9, 10, 11, 12, 13, 14, 15]]

# a short sub-narray was read to the destination's row length
Numo::Int32.zeros(2, 100_000).store([Numo::Int32[1, 2, 3], Numo::Int32.new(100_000).seq])
# before => [BUG] Segmentation fault
# after  => fills 3 elements and zero-fills the rest

# unchanged: a short row is zero-filled whatever kind it is
p Numo::Int32.new(2, 5).fill(9).store([[1, 2, 3], [4, 5, 6]]).to_a
p Numo::Int32.new(2, 5).fill(9).store([Numo::Int32[1, 2, 3], Numo::Int32[4, 5, 6]]).to_a
# both => [[1, 2, 3, 0, 0], [4, 5, 6, 0, 0]]
```

## Related Issues

None.
