### PR TITLE
Fix Numo::Bit#fill writing outside a view that starts past the first word

### DIFF
--- a/ext/numo/narray/src/t_bit.c
+++ b/ext/numo/narray/src/t_bit.c
@@ -130,6 +130,8 @@ static void iter_bit_fill(na_loop_t* const lp) {
       p3 += s3;
     }
   } else {
+    a3 += p3 / NB;
+    p3 %= NB;
     if (p3 > 0 || n < NB) {
       len = (int)(NB - p3);
       if ((int)n < len) {

--- a/test/test_bit.rb
+++ b/test/test_bit.rb
@@ -218,4 +218,27 @@ class NArrayBitTest < NArrayTestBase
     assert_in_delta(0.7071068, m_rms[0])
     assert_in_delta(0.7071068, m_rms[1])
   end
+
+  def test_fill_of_a_view_past_the_first_word
+    a = Numo::Bit.new(4, 11).fill(0)
+    a[[0, 3], true].fill(1)
+    assert_equal(22, a.count_true)
+    assert_equal([1, 0, 0, 1], a[true, 0].to_a)
+
+    b = Numo::Bit.new(8, 9).fill(0)
+    b[[3, 0, 5], true].fill(1)
+    assert_equal(27, b.count_true)
+    assert_equal([1, 0, 0, 1, 0, 1, 0, 0], b[true, 0].to_a)
+
+    [0, 31, 32, 33, 64, 65, 100].each do |offset|
+      c = Numo::Bit.new(200).fill(0)
+      c[offset...(offset + 8)].fill(1)
+      assert_equal((offset...(offset + 8)).to_a, c.where.to_a)
+    end
+
+    d = Numo::Bit.new(4, 11).fill(1)
+    d[[1, 2], true].fill(0)
+    assert_equal(22, d.count_true)
+    assert_equal([1, 0, 0, 1], d[true, 0].to_a)
+  end
 end


### PR DESCRIPTION
## Purpose

`Numo::Bit#fill` on a view that starts past bit 32 writes to the wrong words, silently corrupting bits outside the view.

## Summary of Changes

- Advance `a3` and reduce `p3` modulo `NB` at the top of the word-wise branch of `iter_bit_fill()`, the way `iter_bit_store_bit()`, `iter_bit_copy()`, `iter_bit_not()`, `iter_bit_and()`, `iter_bit_or()`, `iter_bit_xor()` and `iter_bit_eq()` all already do.
- Add a regression test.

`INIT_PTR_BIT_IDX()` hands each iterator the absolute bit position, so every word-wise iterator has to normalize it itself. `iter_bit_fill()` was the only one of the eight that did not, which made `NB - p3` negative for any view starting past bit 32. That both shifts by more than the width of a `BIT_DIGIT` and grows the remaining count, so the write starts at word 0 instead of the word holding the view.

The write stays inside the allocation, so this is silent corruption rather than a memory-safety problem: the bits written past the view all belong to the same NArray. AddressSanitizer reports nothing on the unfixed build.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

236 runs / 0 failures. A differential test against `Numo::Int32#fill` over 23144 cases -- index-array row and column selections on ten shapes, every 1-D slice offset from 0 to 299 at five lengths, and strides 1 to 5 -- reports 0 mismatches; **9261 of those 23144 differ on the unfixed build**.

```ruby
require 'numo/narray'

a = Numo::Bit.new(4, 11).fill(0)
a[[0, 3], true].fill(1)
p a.count_true
# before => 44   (the whole array)
# after  => 22

b = Numo::Bit.new(200).fill(0)
b[33...41].fill(1)
p b.where.to_a
# before => [0, 1, 2, 3, 4, 5, 6, 7, 32, 33, ...]
# after  => [33, 34, 35, 36, 37, 38, 39, 40]
```

An index array is not needed -- any view offset past bit 32 reproduces it, including a plain 1-D slice.

## Related Issues

None.
