### PR TITLE
Fix median counting NaN as values

### DIFF
--- a/ext/numo/narray/src/mh/median.h
+++ b/ext/numo/narray/src/mh/median.h
@@ -38,8 +38,8 @@
     char* p2 = NDL_PTR(lp, 1);                                                                 \
     tDType* buf = (tDType*)p1;                                                                 \
     tDType##_qsort_ignan(buf, n, sizeof(tDType));                                              \
-    for (size_t i = 0; i < n; i++) {                                                           \
-      if (!isnan(buf[i])) break;                                                               \
+    for (; n; n--) {                                                                           \
+      if (!isnan(buf[n - 1])) break;                                                           \
     }                                                                                          \
     if (n == 0) {                                                                              \
       *(tDType*)p2 = buf[0];                                                                   \
@@ -57,8 +57,8 @@
     char* p2 = NDL_PTR(lp, 1);                                                                 \
     tDType* buf = (tDType*)p1;                                                                 \
     tDType##_qsort_prnan(buf, n, sizeof(tDType));                                              \
-    for (size_t i = 0; i < n; i++) {                                                           \
-      if (!isnan(buf[i])) break;                                                               \
+    for (; n; n--) {                                                                           \
+      if (!isnan(buf[n - 1])) break;                                                           \
     }                                                                                          \
     if (n == 0) {                                                                              \
       *(tDType*)p2 = buf[0];                                                                   \

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -1868,6 +1868,17 @@ class NArrayTest < NArrayTestBase
     end
   end
 
+  def test_median_excludes_nan
+    nan = Float::NAN
+    [Numo::DFloat, Numo::SFloat].each do |dtype|
+      assert_in_delta(2.0, dtype[3, nan, 1, nan, 2].median, 1e-6)
+      assert_in_delta(3.0, dtype[4, 3, nan, 1].median, 1e-6)
+      assert_in_delta(2.0, dtype[3, 1, 2].median, 1e-6)
+      assert_predicate(dtype[nan, nan, nan].median, :nan?)
+      assert_equal([2.0, 3.5], dtype[[3, nan, 1], [nan, 2, 5]].median(axis: 1).to_a)
+    end
+  end
+
   def test_comparison_gt
     a = Numo::DFloat[1, 2, 3, 4, 5]
     result = a.gt(3)


### PR DESCRIPTION
## Purpose

`median` counts `NaN` as values instead of dropping them, so a float array containing `NaN` returns the wrong element.

## Summary of Changes

- Restore the loop in `mh/median.h` that trims sorted `NaN` off the tail before the middle element is picked, in both the `ignan` and `prnan` iterators.
- Add a regression test with `NaN` input.

`8f16066` ("refactor: unify median method implementation across types with macro template") rewrote

```c
for (; n; n--) {
  if (!isnan(buf[n - 1])) break;
}
```

as

```c
for (size_t i = 0; i < n; i++) {
  if (!isnan(buf[i])) break;
}
```

which walks a local index and never touches `n`, so it has no effect at all. `qsort_ignan` sorts `NaN` to the end, so the trim has to run from the back.

The `n == 0` branch that follows exists to return `NaN` when every element is `NaN`; it was unreachable while the trim was a no-op, because an empty array is already rejected by `cannot reduce empty NArray`.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

238 runs / 0 failures. The test added with `8f16066` uses no `NaN` input, which is why this went unnoticed; the new test fails on `5948c8e`.

```ruby
require 'numo/narray'

nan = Float::NAN
p Numo::DFloat[3, nan, 1, nan, 2].median
# before => 3.0   (sorts to [1, 2, 3, NaN, NaN] and takes buf[2])
# after  => 2.0

p Numo::DFloat[4, 3, nan, 1].median
# before => 3.5
# after  => 3.0

p Numo::DFloat[[3, nan, 1], [nan, 2, 5]].median(axis: 1).to_a
# before => [3.0, 5.0]
# after  => [2.0, 3.5]

p Numo::DFloat[nan, nan, nan].median  # => NaN, unchanged
```

## Related Issues

None.
