### PR TITLE
Fix a SEGV and heap address leaks from `Numo::RObject` binary I/O

### DIFF
--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1420,7 +1420,7 @@ static VALUE nary_marshal_dump(VALUE self) {
   rb_ary_push(a, INT2FIX(1)); // version
   rb_ary_push(a, na_shape(self));
   rb_ary_push(a, INT2FIX(NA_FLAG0(self)));
-  if (rb_obj_class(self) == numo_cRObject) {
+  if (RTEST(rb_obj_is_kind_of(self, numo_cRObject))) {
     narray_t* na;
     VALUE* ptr;
     size_t offset = 0;
@@ -1474,7 +1474,7 @@ static VALUE nary_marshal_load(VALUE self, VALUE a) {
   na_initialize(self, RARRAY_AREF(a, 1));
   NA_FL0_SET(self, FIX2INT(RARRAY_AREF(a, 2)));
   v = RARRAY_AREF(a, 3);
-  if (rb_obj_class(self) == numo_cRObject) {
+  if (RTEST(rb_obj_is_kind_of(self, numo_cRObject))) {
     narray_t* na;
     char* ptr;
     if (TYPE(v) != T_ARRAY) {

--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1261,6 +1261,9 @@ static VALUE nary_s_from_binary(int argc, VALUE* argv, VALUE type) {
   VALUE vstr, vshape, vna;
   VALUE velmsz;
 
+  if (RTEST(rb_class_inherited_p(type, numo_cRObject))) {
+    rb_raise(rb_eTypeError, "cannot restore %s from binary data", rb_class2name(type));
+  }
   narg = rb_scan_args(argc, argv, "11", &vstr, &vshape);
   Check_Type(vstr, T_STRING);
   str_len = RSTRING_LEN(vstr);
@@ -1340,6 +1343,9 @@ static VALUE nary_store_binary(int argc, VALUE* argv, VALUE self) {
   VALUE velmsz;
   narray_t* na;
 
+  if (RTEST(rb_obj_is_kind_of(self, numo_cRObject))) {
+    rb_raise(rb_eTypeError, "cannot store binary data to %s", rb_obj_classname(self));
+  }
   narg = rb_scan_args(argc, argv, "11", &vstr, &voffset);
   Check_Type(vstr, T_STRING);
   str_len = RSTRING_LEN(vstr);
@@ -1392,6 +1398,9 @@ static VALUE nary_to_binary(VALUE self) {
   narray_t* na;
   int offset_in_bits;
 
+  if (RTEST(rb_obj_is_kind_of(self, numo_cRObject))) {
+    rb_raise(rb_eTypeError, "cannot convert %s into binary data", rb_obj_classname(self));
+  }
   GetNArray(self, na);
   if (na->type == NARRAY_VIEW_T) {
     offset_in_bits = RTEST(rb_obj_is_kind_of(self, numo_cBit)) && NA_VIEW_OFFSET(na) != 0;

--- a/ext/numo/narray/src/t_robject.c
+++ b/ext/numo/narray/src/t_robject.c
@@ -405,7 +405,10 @@ void Init_numo_robject(void) {
   /* Stride size of contiguous RObject array. */
   rb_define_const(cT, "CONTIGUOUS_STRIDE", INT2FIX(sizeof(dtype)));
   rb_undef_method(rb_singleton_class(cT), "from_binary");
+  rb_undef_method(rb_singleton_class(cT), "from_string");
+  rb_undef_method(cT, "store_binary");
   rb_undef_method(cT, "to_binary");
+  rb_undef_method(cT, "to_string");
   rb_undef_method(cT, "swap_byte");
   rb_undef_method(cT, "to_network");
   rb_undef_method(cT, "to_vacs");

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -4,6 +4,7 @@ require_relative 'test_helper'
 
 class NArrayTest < NArrayTestBase
   class BitSubclass < Numo::Bit; end
+  class RObjectSubclass < Numo::RObject; end
 
   def test_inheritance_relationship
     TYPES.each do |dtype|
@@ -2046,6 +2047,14 @@ class NArrayTest < NArrayTestBase
     assert_equal(bits.join, a.to_binary.unpack1('b*'))
     assert_equal(bits[8, 8], a[8..15].to_a)
     assert_raises(Numo::NArray::CastError) { a[8..15].to_binary }
+  end
+
+  def test_marshal_of_an_robject_subclass_does_not_expose_raw_values
+    a = RObjectSubclass.new(2).allocate.store([+'hello', +'world'])
+    dumped = a.marshal_dump
+
+    assert_equal([1, [2], 0, %w[hello world]], dumped)
+    assert_equal(%w[hello world], Marshal.load(Marshal.dump(a)).to_a)
   end
 
   def test_marshal_load_rejects_a_non_array_shape

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2057,6 +2057,25 @@ class NArrayTest < NArrayTestBase
     assert_equal(%w[hello world], Marshal.load(Marshal.dump(a)).to_a)
   end
 
+  def test_robject_rejects_binary_io
+    a = Numo::RObject[1, 2, 3]
+    bytes = "\x00" * 24
+
+    assert_raises(NoMethodError) { a.store_binary(bytes) }
+    assert_raises(NoMethodError) { a.to_binary }
+    assert_raises(NoMethodError) { a.to_string }
+    assert_raises(NoMethodError) { RObjectSubclass.new(3).allocate.store_binary(bytes) }
+    assert_raises(NoMethodError) { Numo::RObject.from_binary(bytes) }
+    assert_raises(NoMethodError) { Numo::RObject.from_string(bytes) }
+    assert_raises(NoMethodError) { RObjectSubclass.from_binary(bytes) }
+
+    assert_raises(TypeError) { Numo::NArray.instance_method(:store_binary).bind_call(a, bytes) }
+    assert_raises(TypeError) { Numo::NArray.instance_method(:to_binary).bind_call(a) }
+    assert_raises(TypeError) do
+      Numo::NArray.singleton_class.instance_method(:from_binary).bind_call(RObjectSubclass, bytes)
+    end
+  end
+
   def test_marshal_load_rejects_a_non_array_shape
     [42, 'AAAAAAAAAAAAAAAA', nil, {}, 1.5, :abc, true, Object.new].each do |bad|
       assert_raises(ArgumentError) { Numo::DFloat.allocate.marshal_load([1, bad, 0, +'']) }


### PR DESCRIPTION

## Purpose

`Numo::RObject` stores raw `VALUE`s, so its binary representation is a list of object pointers. `store_binary` and `from_string` turn attacker-chosen bytes into object references, and `to_string` hands out heap addresses.

```ruby
bytes = [0x00007f0000001000].pack('Q') * 8
a = Numo::RObject.new(8)
a.store_binary(bytes)
GC.start
# <internal:gc>:44: [BUG] Segmentation fault at 0x00007f0000000000
```

`from_binary` and `to_binary` are already undefined for `Numo::RObject`, but the `from_string` and `to_string` aliases are separate entries on `Numo::NArray`, so `rb_undef_method` on the subclass does not reach them, and `store_binary` was never undefined at all.

## Summary of Changes

- Use `rb_obj_is_kind_of` instead of an exact class comparison in `marshal_dump` and `marshal_load`, so `Numo::RObject` subclasses take the same Array-based path as `Numo::RObject` itself.
- Undefine `from_string`, `to_string` and `store_binary` for `Numo::RObject` alongside the two names already undefined.
- Reject `Numo::RObject` in `nary_s_from_binary`, `nary_store_binary` and `nary_to_binary`, so a bound `UnboundMethod` cannot get around the undef.

The marshal change comes first because the binary guard would otherwise break `Marshal` for subclasses: they currently fall into the `nary_to_binary` / `nary_store_binary` branch, which serializes the pointers verbatim.

```ruby
class MyRO < Numo::RObject; end
a = MyRO.new(2).allocate.store([+'hello', +'world'])
Marshal.dump(a)
# before => "\x04\bU:\tMyRO[\ti\x06[\x06i\ai\x00I\"\x15\xA8\xCB\xB8R\x1A\x7F\x00\x00..."
#                                          ^^^^^^^^^^^^^^^^^^^^^^ 0x00007f1a52b8cba8
# after  => "\x04\bU:\tMyRO[\ti\x06[\x06i\ai\x00[\aI\"\nhello\x06:\x06ETI\"\nworld\x06;\x06T"
```

`Numo::Struct` cannot declare an object member, so the exposure is limited to `Numo::RObject` and its subclasses.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

237 runs / 0 failures. Both new tests fail on `5948c8e`.

```ruby
require 'numo/narray'

a = Numo::RObject[1, 2, 3]
bytes = "\x00" * 24

a.store_binary(bytes)              # before: stores forged VALUEs, after: NoMethodError
Numo::RObject.from_string(bytes)   # before: builds forged VALUEs, after: NoMethodError
Numo::RObject[1, 2, 3].to_string   # before: "\x03\x00...\x05\x00...\x07\x00...", after: NoMethodError

# the undef alone is not enough
Numo::NArray.instance_method(:store_binary).bind_call(a, bytes)
# before: stores forged VALUEs, after: TypeError

# unchanged
Marshal.load(Marshal.dump(Numo::RObject[1, 'x', nil])).to_a  # => [1, "x", nil]
Numo::DFloat.from_binary([1.5, 2.5].pack('d2')).to_a         # => [1.5, 2.5]
```

## Related Issues

None.
