### PR TITLE
Fix a heap buffer overflow and misplaced writes from `store_binary` on a view

### DIFF
--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1334,7 +1334,7 @@ static VALUE nary_s_from_binary(int argc, VALUE* argv, VALUE type) {
     @return [Integer] stored length.
  */
 static VALUE nary_store_binary(int argc, VALUE* argv, VALUE self) {
-  size_t size, str_len, byte_size, offset;
+  size_t size, str_len, byte_size, offset, view_offset = 0;
   int narg;
   VALUE vstr, voffset;
   VALUE velmsz;
@@ -1369,12 +1369,34 @@ static VALUE nary_store_binary(int argc, VALUE* argv, VALUE self) {
     rb_raise(rb_eArgError, "string is too short to store");
   }
 
-  if (OBJ_FROZEN(vstr)) {
+  if (na->type == NARRAY_VIEW_T) {
+    narray_t* nab;
+    size_t data_byte_size;
+
+    if (na_check_contiguous(self) == Qfalse) {
+      rb_raise(rb_eStandardError, "cannot store binary data to non-contiguous NArray");
+    }
+    view_offset = NA_VIEW_OFFSET(na);
+    if (!FIXNUM_P(velmsz) && view_offset != 0) {
+      rb_raise(rb_eStandardError, "cannot store binary data to NArray view offset in bits");
+    }
+    GetNArray(NA_VIEW_DATA(na), nab);
+    if (FIXNUM_P(velmsz)) {
+      data_byte_size = NA_SIZE(nab) * NUM2SIZET(velmsz);
+    } else {
+      data_byte_size = ceil(NA_SIZE(nab) * NUM2DBL(velmsz));
+    }
+    if (view_offset > data_byte_size || byte_size > data_byte_size - view_offset) {
+      rb_raise(rb_eArgError, "string is too long to store");
+    }
+  }
+
+  if (OBJ_FROZEN(vstr) && na->type != NARRAY_VIEW_T) {
     na_set_pointer(self, RSTRING_PTR(vstr) + offset, byte_size);
     rb_ivar_set(self, id_source, vstr);
   } else {
-    void* ptr = na_get_pointer_for_write(self);
-    memcpy(ptr, RSTRING_PTR(vstr) + offset, byte_size);
+    char* ptr = na_get_pointer_for_write(self);
+    memcpy(ptr + view_offset, RSTRING_PTR(vstr) + offset, byte_size);
   }
 
   return SIZET2NUM(byte_size);

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2071,6 +2071,35 @@ class NArrayTest < NArrayTestBase
     assert_equal(a, Marshal.load(Marshal.dump(a)))
   end
 
+  def test_store_binary_to_a_view_uses_the_view_offset
+    a = Numo::DFloat.new(2, 3).seq
+    a[1, true].store_binary([9.0, 8.0, 7.0].pack('d3'))
+
+    assert_equal([[0.0, 1.0, 2.0], [9.0, 8.0, 7.0]], a.to_a)
+
+    b = Numo::DFloat.new(4).seq
+    b[1..2].store_binary([9.0, 8.0].pack('d2').freeze)
+
+    assert_equal([0.0, 9.0, 8.0, 3.0], b.to_a)
+    assert_equal(32, b.byte_size)
+    assert_equal(32, b.to_binary.bytesize)
+
+    c = Numo::Bit.new(64).fill(0)
+
+    assert_equal(4, c[0...32].store_binary("\xFF".b * 4))
+    assert_equal(32, c.count_true)
+    assert_equal(32, c[0...32].count_true)
+  end
+
+  def test_store_binary_rejects_a_view_it_cannot_place
+    a = Numo::DFloat.new(1).seq
+
+    assert_raises(StandardError) { a[[0] * 100_000].store_binary("\xAA".b * (100_000 * 8)) }
+    assert_raises(StandardError) { Numo::DFloat.new(4).seq.reverse.store_binary(([1.0] * 4).pack('d4')) }
+    assert_raises(StandardError) { Numo::DFloat.new(4).seq[[0, 2]].store_binary(([1.0] * 2).pack('d2')) }
+    assert_raises(StandardError) { Numo::Bit.new(64).fill(0)[8...40].store_binary("\xFF".b * 4) }
+  end
+
   def test_store_binary_to_binary
     (TYPES - [Numo::RObject]).each do |dtype|
       a = dtype[1, 2, 3, 4, 5]


### PR DESCRIPTION

## Purpose

`store_binary` sizes the copy from `NA_SIZE(na)`, which is the *view's* logical element count, but writes to `na_get_pointer_for_write(self)`, which returns the start of the *underlying* buffer. The view offset never applies.

```ruby
a = Numo::DFloat.new(1).seq        # 8 bytes allocated
v = a[[0] * 100_000]               # 100000 logical elements
v.store_binary("\xAA" * 800_000)   # writes 800000 bytes
# => [BUG] Segmentation fault
```

The same mismatch corrupts data silently when the copy does fit:

```ruby
a = Numo::DFloat.new(2, 3).seq
a[1, true].store_binary([9.0, 8.0, 7.0].pack('d3'))
a.to_a  # => [[9.0, 8.0, 7.0], [3.0, 4.0, 5.0]]   row 1 was meant, row 0 was written
```

A frozen String takes the zero-copy `na_set_pointer` path, which replaces the *base* data pointer with the shorter String buffer, so every later read runs off the end:

```ruby
a = Numo::DFloat.new(100_000).seq
a[0..1].store_binary([1.0, 2.0].pack('d2').freeze)
a.byte_size  # => 800000, backed by a 16-byte String buffer
a.sum        # => NaN
```

## Summary of Changes

- Copy at the view offset instead of the start of the buffer, so a row view writes to its own row.
- Reject views that cannot be placed there: non-contiguous ones, and `Numo::Bit` views whose offset is in bits, the same case `to_binary` already refuses.
- Check the copy against the base allocation as well, so the bound does not rest on the contiguity test alone.
- Keep the zero-copy frozen-String path for non-view NArrays only; a view now always copies.

Rejecting every view would also close the overflow, but `a[1, true].store_binary(...)` is a reasonable thing to write and it silently corrupts row 0 today, so it seemed better to make it land in the right place.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

237 runs / 0 failures. The new tests segfault on `5948c8e`.

```ruby
require 'numo/narray'

a = Numo::DFloat.new(1).seq
a[[0] * 100_000].store_binary("\xAA" * 800_000)
# before => [BUG] Segmentation fault
# after  => cannot store binary data to non-contiguous NArray (StandardError)

b = Numo::DFloat.new(2, 3).seq
b[1, true].store_binary([9.0, 8.0, 7.0].pack('d3'))
p b.to_a
# before => [[9.0, 8.0, 7.0], [3.0, 4.0, 5.0]]
# after  => [[0.0, 1.0, 2.0], [9.0, 8.0, 7.0]]

c = Numo::DFloat.new(4).seq
c[1..2].store_binary([9.0, 8.0].pack('d2').freeze)
p [c.to_a, c.to_binary.bytesize]
# before => [[9.0, 8.0, 0.0, 0.0], 32]   only 16 bytes are backing it
# after  => [[0.0, 9.0, 8.0, 3.0], 32]

# unchanged
d = Numo::DFloat.new(2)
d.store_binary([1.5, 2.5].pack('d2'))
p d.to_a  # => [1.5, 2.5]
```

## Related Issues

None.
