### PR TITLE
Fix wrong reduction results from `expand_dims` exceeding the dimension limit

### DIFF
--- a/ext/numo/narray/narray.c
+++ b/ext/numo/narray/narray.c
@@ -1058,6 +1058,7 @@ static VALUE na_expand_dims(VALUE self, VALUE vdim) {
 
   GetNArray(self, na);
   nd = na->ndim;
+  na_check_ndim(nd + 1);
 
   dim = NUM2INT(vdim);
   if (dim < -nd - 1 || dim > nd) {

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2305,6 +2305,19 @@ class NArrayTest < NArrayTestBase
     assert_raises(ArgumentError) { Numo::DFloat.new(1, 2, -3) }
   end
 
+  def test_expand_dims_rejects_exceeding_the_maximum_dimension
+    a = Numo::DFloat.new(*([1] * 62)).seq
+
+    assert_equal(62, a.ndim)
+    assert_raises(Numo::NArray::DimensionError) { a.expand_dims(0) }
+    assert_raises(Numo::NArray::DimensionError) { a.expand_dims(-1) }
+    assert_equal(62, a.ndim)
+
+    b = Numo::DFloat.new(*([1] * 61)).seq
+
+    assert_equal(62, b.expand_dims(0).ndim)
+  end
+
   def test_new_rejects_shape_whose_element_count_overflows
     assert_raises(RangeError) { Numo::Int8.new((2**62) + 1, 4) }
     assert_raises(RangeError) { Numo::DFloat.new(2**32, 2**32) }


### PR DESCRIPTION

## Purpose

`na_expand_dims` builds an `ndim + 1` view without calling `na_check_ndim`, so an NArray already at `NA_MAX_DIMENSION` can grow past the limit the library declares. Code that assumes the limit holds then misbehaves.

```ruby
a = Numo::DFloat.new(*([1] * 62)).seq   # NA_MAX_DIMENSION == 62
v = a.expand_dims(0)                    # ndim == 63
v.transpose                             # => ndim=63 is too many (Numo::NArray::DimensionError)
```

Reduction over an axis returns a wrong shape instead of raising:

```ruby
a = Numo::DFloat.new(*([1] * 61), 4).seq
v = a.expand_dims(0)     # ndim == 63
v.sum(axis: 0).ndim      # => 59, expected 62
v.sum(axis: 61)          # => Float, every dimension collapses
```

Every other entry point (`new`, `reshape`, `from_binary`, `Numo::Struct`) checks the limit; `expand_dims` is the only one that does not.

## Summary of Changes

- Call `na_check_ndim(nd + 1)` before building the view, so `expand_dims` raises `DimensionError` instead of producing an out-of-range NArray.
- Add a regression test at the boundary.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

236 runs / 0 failures. The new test fails on `5948c8e`.

```ruby
require 'numo/narray'

a = Numo::DFloat.new(*([1] * 62)).seq
a.expand_dims(0)
# before => a 63-dimensional view
# after  => ndim=63 is too many (Numo::NArray::DimensionError)

b = Numo::DFloat.new(*([1] * 61)).seq
p b.expand_dims(0).ndim  # => 62, unchanged
```

## Related Issues

None.
