### PR TITLE
Fix `Numo::RObject` subclasses storing the source array into every element

### DIFF
--- a/ext/numo/narray/src/mh/store.h
+++ b/ext/numo/narray/src/mh/store.h
@@ -487,7 +487,7 @@ static inline bool na_store_rary_fetch(VALUE ary, size_t i, VALUE* x) {
       robject_store_uint8(self, obj);                                                          \
       return self;                                                                             \
     }                                                                                          \
-    if (klass == numo_cRObject) {                                                              \
+    if (RTEST(rb_obj_is_kind_of(obj, numo_cRObject))) {                                        \
       robject_store_robject(self, obj);                                                        \
       return self;                                                                             \
     }                                                                                          \

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -2235,6 +2235,24 @@ class NArrayTest < NArrayTestBase
     assert_equal(Numo::DFloat[5, 7, 9], result)
   end
 
+  def test_store_of_an_robject_subclass_is_element_wise
+    subclass = Class.new(Numo::RObject)
+    a = subclass.new(6).allocate.store([1, 2, 3, 4, 5, 6])
+
+    assert_equal([1, 2, 3, 4, 5, 6], a.dup.to_a)
+    assert_equal(subclass, a.dup.class)
+    assert_equal([[1, 2, 3], [4, 5, 6]], a.reshape(2, 3).to_a)
+    assert_equal([[1, 4], [2, 5], [3, 6]], a.reshape(2, 3).transpose.to_a)
+    assert_equal([2, 3, 4, 5, 6, 7], (a + 1).to_a)
+    assert_equal(21, a.sum)
+    assert_equal([0, 0, 1, 0, 0, 0], a.eq(3).to_a)
+    assert_equal([1, 2, 3, 4, 5, 6], Numo::RObject.cast(a).to_a)
+
+    assert_equal([0.0, 1.0, 2.0], Numo::RObject.new(3).store(Numo::DFloat[0, 1, 2]).to_a)
+    assert_equal(%w[x x x], Numo::RObject.new(3).store(+'x').to_a)
+    assert_equal([1, 2, 3], Numo::RObject.new(3).store([1, 2, 3]).to_a)
+  end
+
   def test_shape_error_on_binary_operations
     a = Numo::DFloat[1, 2, 3]
     b = Numo::DFloat[1, 2]


### PR DESCRIPTION

## Purpose

`robject_store` dispatches on the exact class, so a subclass of `Numo::RObject` matches no branch and falls through to `robject_store_numeric`, which wraps its argument in a 0-dimensional `RObject` and broadcasts it. Every element ends up holding the source array itself.

```ruby
class MyRO < Numo::RObject; end
a = MyRO.new(3).allocate.store([1, 2, 3])

a.dup.to_a               # => [MyRO#shape=[3] [1,2,3], MyRO#shape=[3] [1,2,3], MyRO#shape=[3] [1,2,3]]
a.dup.to_a[0].equal?(a)  # => true
a.dup.sum                # => SystemStackError
a.eq(2).to_a             # => [0, 0, 0]   no exception, just wrong
```

`reshape`, `transpose` and `Numo::RObject.cast` produce the same nesting, and `+` raises `SystemStackError` as well. `eq` is the quiet one: the elements are arrays, so no comparison ever matches.

Every other dtype raises `CastError: unknown conversion from MyF to MyF` for the same shape of call, and `Numo::RObject#[]=` already raises `CastError: unknown conversion from MyF to Numo::RObject`, so `Numo::RObject#store` is the only path that fails silently.

## Summary of Changes

- Match `Numo::RObject` with `rb_obj_is_kind_of` instead of an exact class comparison, so a subclass reaches `robject_store_robject` and stores element by element.
- Add a regression test covering `dup`, `reshape`, `transpose`, `+`, `sum`, `eq` and `cast` on a subclass.

The `IsNArray(obj)` fallback below it is left alone. It calls `obj.coerce_cast(Numo::RObject)`, which cannot succeed today because `DEF_NARRAY_COERCE_CAST_METHOD_FUNC` returns `Qnil` for every dtype, so any other NArray still lands on the broadcast. Turning that into a `CastError` would also change `Numo::RObject.cast(Numo::DComplex[...])`, which `test_cast` currently asserts produces elements that are the whole source array; that seemed like a separate decision.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

236 runs / 0 failures. The new test fails on `5948c8e`.

```ruby
require 'numo/narray'

class MyRO < Numo::RObject; end
a = MyRO.new(6).allocate.store([1, 2, 3, 4, 5, 6])

p a.dup.to_a
# before => [MyRO#shape=[6] [1,2,3,4,5,6], ...] six times
# after  => [1, 2, 3, 4, 5, 6]

p a.reshape(2, 3).transpose.to_a
# before => nested MyRO instances
# after  => [[1, 4], [2, 5], [3, 6]]

p a.sum
# before => SystemStackError
# after  => 21

p a.eq(3).to_a
# before => [0, 0, 0, 0, 0, 0]
# after  => [0, 0, 1, 0, 0, 0]

# unchanged
p Numo::RObject.new(3).store(Numo::DFloat[0, 1, 2]).to_a  # => [0.0, 1.0, 2.0]
p Numo::RObject.new(3).store(+'x').to_a                   # => ["x", "x", "x"]
```

## Related Issues

None.
