### PR TITLE
Fix an infinite loop in `**` with a negative exponent on unsigned integer types

### DIFF
--- a/ext/numo/narray/numo/types/uint_macro.h
+++ b/ext/numo/narray/numo/types/uint_macro.h
@@ -26,6 +26,7 @@ static dtype pow_int(dtype x, int p) {
   case 3:
     return x * x * x;
   }
+  if (p < 0) return 0;
   while (p) {
     if (p & 1) r *= x;
     x *= x;

--- a/test/test_narray.rb
+++ b/test/test_narray.rb
@@ -1477,6 +1477,16 @@ class NArrayTest < NArrayTestBase
     end
   end
 
+  def test_pow_with_a_negative_exponent_is_zero
+    (INTEGER_TYPES + UNSIGNED_INTEGER_TYPES).each do |dtype|
+      a = dtype[1, 2, 3, 4]
+
+      assert_equal(dtype[1, 1, 1, 1], a**0)
+      assert_equal(dtype[0, 0, 0, 0], a**-1)
+      assert_equal(dtype[0, 0, 0, 0], a**-2)
+    end
+  end
+
   def test_eye
     TYPES.each do |dtype|
       assert_equal(dtype[[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype.new(3, 3).eye)


### PR DESCRIPTION

## Purpose

`pow_int` in `numo/types/uint_macro.h` never returns for a negative exponent. `p >>= 1` on a negative `int` is an arithmetic shift, so `p` sinks to `-1` and stays there, and `while (p)` never ends. `UInt8` / `UInt16` / `UInt32` / `UInt64` are all affected.

```ruby
Numo::Int32[1, 2, 3, 4] ** -2   # => [0, 0, 0, 0]
Numo::UInt8[1, 2, 3, 4] ** -2   # never returns
```

The loop has no interrupt check, so the process ignores `SIGTERM` and needs `SIGKILL`.

The signed version at `numo/types/int_macro.h:37` already has the guard in the same position; only the unsigned copy is missing it.

## Summary of Changes

- Return `0` for a negative exponent in `uint_macro.h`, matching the signed integer types.
- Add a regression test over `INTEGER_TYPES` and `UNSIGNED_INTEGER_TYPES`.

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

236 runs / 0 failures. The new test hangs on `5948c8e` instead of failing, so a regression would stall the suite rather than report an error.

```ruby
require 'numo/narray'

p Numo::UInt8[1, 2, 3, 4] ** -2
# before => never returns
# after  => Numo::UInt8[0, 0, 0, 0]

p Numo::UInt32[1, 2] ** Numo::UInt32[0x8000_0000]
# before => never returns (the exponent narrows to a negative int)
# after  => Numo::UInt32[0, 0]

p Numo::UInt8[1, 2, 3, 4] ** Numo::Int32[-2, -1, 2, 3]
# => Numo::Int32[0, 0, 9, 64], unchanged (upcast to Int32 already took the guarded path)
```

## Related Issues

None.
